### PR TITLE
fix/63 -- Use renderModule from backend message to normalize search entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,6 +190,12 @@
 			"integrity": "sha512-pRs2gYF5yoKYrgSaira0DJqVg2tFuF+Qjp838xS7K+mJyY2jJzjsrl6y17GbIa4uMRogMbxs+ghNCvKg6XyNrA==",
 			"dev": true
 		},
+		"@types/uuid": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+			"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+			"dev": true
+		},
 		"@types/ws": {
 			"version": "7.2.6",
 			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
@@ -6834,9 +6840,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"dev": true
 		},
 		"v8-compile-cache": {
@@ -7168,6 +7174,14 @@
 			"requires": {
 				"ansi-colors": "^3.0.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
 			}
 		},
 		"webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"@types/jasmine": "^3.5.10",
 		"@types/node-fetch": "^2.5.7",
 		"@types/utf8": "^2.1.6",
+		"@types/uuid": "^8.3.0",
 		"@types/ws": "^7.2.6",
 		"@typescript-eslint/eslint-plugin": "^2.34.0",
 		"@typescript-eslint/parser": "^2.34.0",
@@ -86,6 +87,7 @@
 		"rxjs": "6.0.0",
 		"ts-node": "^9.0.0",
 		"typescript": "^3.9.6",
+		"uuid": "^8.3.2",
 		"webpack": "^4.43.0",
 		"yargs": "^15.4.1"
 	}

--- a/src/functions/searches/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search.spec.ts
@@ -80,7 +80,7 @@ describe('subscribeToOneSearch()', () => {
 			const latest = result[result.length - 1] as TextSearchEntries;
 			const lastEntry = latest.data[latest.data.length - 1];
 			expect(lastEntry).toBeDefined();
-			expect(base64.decode(lastEntry.value)).toEqual('count 1000');
+			expect(base64.decode(lastEntry.value)).toEqual(`count ${count}`);
 		}),
 		25000,
 	);

--- a/src/functions/searches/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search.spec.ts
@@ -6,59 +6,81 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { subDays } from 'date-fns';
+import * as base64 from 'base-64';
+import { addMinutes } from 'date-fns';
+import { concat, from } from 'rxjs';
+import { filter, first, last, takeUntil, toArray } from 'rxjs/operators';
+import { TextSearchEntries } from 'src/models/search/search-entries';
+import { v4 as uuidv4 } from 'uuid';
 import { integrationTest } from '../../tests';
 import { TEST_BASE_API_CONTEXT } from '../../tests/config';
+import { sleep } from '../../tests/utils';
+import { makeIngestMultiLineEntry } from '../ingestors/ingest-multi-line-entry';
+import { makeGetAllTags } from '../tags/get-all-tags';
 import { makeSubscribeToOneSearch } from './subscribe-to-one-search/subscribe-to-one-search';
 
-xdescribe('subscribeToOneSearch()', () => {
+describe('subscribeToOneSearch()', () => {
+	// Use a randomly generated tag, so that we know exactly what we're going to query
+	const tag = uuidv4();
+
+	// The number of entries to generate
+	const count = 1000;
+
+	// The start date for generated queries
+	const start = new Date(2010, 0, 0);
+
+	// The end date for generated queries
+	const end = addMinutes(start, count - 1);
+
+	beforeAll(async () => {
+		// Generate and ingest some entries
+		const ingestMultiLineEntry = makeIngestMultiLineEntry(TEST_BASE_API_CONTEXT);
+		const values: Array<string> = [];
+		for (let i = 0; i < count; i++) {
+			values.push(JSON.stringify({ timestamp: addMinutes(start, i), value: i }));
+		}
+		const data: string = values.join('\n');
+		await ingestMultiLineEntry({ data, tag, assumeLocalTimezone: false });
+
+		// Check the list of tags until our new tag appears
+		const getAllTags = makeGetAllTags(TEST_BASE_API_CONTEXT);
+		while (!(await getAllTags()).includes(tag)) {
+			// Give the backend a moment to catch up
+			await sleep(1000);
+		}
+	}, 25000);
+
 	it(
 		'Should work with queries using the raw renderer',
 		integrationTest(async () => {
 			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
-			const query = 'tag=netflow netflow Src Bytes | count Bytes by Src';
-			const range: [Date, Date] = [subDays(new Date(), 7), new Date()];
+			const query = `tag=${tag} json value | count`;
+			const range: [Date, Date] = [start, end];
 			const search = await subscribeToOneSearch(query, range);
 
-			search.progress$.subscribe(progress => console.log(`Progress ${progress}`));
-			search.entries$.subscribe(entries => console.log(`Entries`, entries));
-			search.stats$.subscribe(stats => console.log(`Stats`, stats));
+			const result = await search.entries$
+				.pipe(
+					takeUntil(
+						concat(
+							// Wait for progress == 100...
+							search.progress$.pipe(
+								filter(progress => progress == 100),
+								first(),
+							),
+							// ... then sleep after progress == 100 to make sure we have every entry
+							from(sleep(1000)),
+						).pipe(last()),
+					),
+					toArray(),
+				)
+				.toPromise();
 
-			await new Promise(res => setTimeout(res, 10000));
-		}),
-		25000,
-	);
+			expect(result.length).toBeGreaterThan(0);
 
-	it(
-		'Should work with queries using the chart renderer',
-		integrationTest(async () => {
-			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
-			const query = 'tag=netflow netflow Bytes Src | count Bytes by Src | chart count by Src';
-			const range: [Date, Date] = [subDays(new Date(), 7), new Date()];
-			const search = await subscribeToOneSearch(query, range);
-
-			search.progress$.subscribe(progress => console.log(`Progress ${progress}`));
-			search.entries$.subscribe(entries => console.log(`Entries`, entries));
-			search.stats$.subscribe(stats => console.log(`Stats`, stats));
-
-			await new Promise(res => setTimeout(res, 10000));
-		}),
-		25000,
-	);
-
-	it(
-		'Should work with queries using the table renderer',
-		integrationTest(async () => {
-			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
-			const query = 'tag=netflow netflow Src Dst | table';
-			const range: [Date, Date] = [subDays(new Date(), 7), new Date()];
-			const search = await subscribeToOneSearch(query, range);
-
-			search.progress$.subscribe(progress => console.log(`Progress ${progress}`));
-			search.entries$.subscribe(entries => console.log(`Entries`, entries));
-			search.stats$.subscribe(stats => console.log(`Stats`, stats));
-
-			await new Promise(res => setTimeout(res, 10000));
+			const latest = result[result.length - 1] as TextSearchEntries;
+			const lastEntry = latest.data[latest.data.length - 1];
+			expect(lastEntry).toBeDefined();
+			expect(base64.decode(lastEntry.value)).toEqual('count 1000');
 		}),
 		25000,
 	);

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
@@ -10,6 +10,7 @@ import { isBoolean, isEqual, isNil, isNull, isUndefined } from 'lodash';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { bufferCount, distinctUntilChanged, filter, first, map, startWith, tap } from 'rxjs/operators';
 import {
+	normalize,
 	Query,
 	RawAcceptSearchMessageSent,
 	RawInitiateSearchMessageSent,
@@ -23,7 +24,6 @@ import {
 	SearchMessageCommands,
 	SearchStats,
 	SearchSubscription,
-	toSearchEntries,
 } from '../../../models';
 import { Percentage, toNumericID } from '../../../value-objects';
 import { APIContext, promiseProgrammatically } from '../../utils';
@@ -115,7 +115,7 @@ export const makeSubscribeToOneSearch = (context: APIContext) => {
 					return false;
 				}
 			}),
-			map(msg => toSearchEntries(rendererType, msg)),
+			map(msg => normalize(rendererType, msg)),
 			tap(entries => {
 				const defDesiredGranularity = getDefaultGranularityByRendererType(entries.type);
 				initialFilter.desiredGranularity = defDesiredGranularity;

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
@@ -10,7 +10,6 @@ import { isBoolean, isEqual, isNil, isNull, isUndefined } from 'lodash';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { bufferCount, distinctUntilChanged, filter, first, map, startWith, tap } from 'rxjs/operators';
 import {
-	normalize,
 	Query,
 	RawAcceptSearchMessageSent,
 	RawInitiateSearchMessageSent,
@@ -24,6 +23,7 @@ import {
 	SearchMessageCommands,
 	SearchStats,
 	SearchSubscription,
+	toSearchEntries,
 } from '../../../models';
 import { Percentage, toNumericID } from '../../../value-objects';
 import { APIContext, promiseProgrammatically } from '../../utils';
@@ -115,7 +115,7 @@ export const makeSubscribeToOneSearch = (context: APIContext) => {
 					return false;
 				}
 			}),
-			map(msg => normalize(rendererType, msg)),
+			map(msg => toSearchEntries(rendererType, msg)),
 			tap(entries => {
 				const defDesiredGranularity = getDefaultGranularityByRendererType(entries.type);
 				initialFilter.desiredGranularity = defDesiredGranularity;

--- a/src/models/search/raw-search-message-received/request-entries-within-range/index.ts
+++ b/src/models/search/raw-search-message-received/request-entries-within-range/index.ts
@@ -7,6 +7,7 @@
  **************************************************************************/
 
 import { RawSearchMessageReceivedRequestEntriesWithinRangeChartRenderer } from './chart-renderer';
+import { RawSearchMessageReceivedRequestEntriesWithinRangeFDGRenderer } from './fdg-renderer';
 import { RawSearchMessageReceivedRequestEntriesWithinRangeGaugeRenderer } from './gauge-renderer';
 import { RawSearchMessageReceivedRequestEntriesWithinRangeHeatmapRenderer } from './heatmap-renderer';
 import { RawSearchMessageReceivedRequestEntriesWithinRangePointToPointRenderer } from './point-to-point-renderer';
@@ -18,6 +19,7 @@ import { RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer } from '.
 
 export type RawSearchMessageReceivedRequestEntriesWithinRangeData =
 	| RawSearchMessageReceivedRequestEntriesWithinRangeChartRenderer
+	| RawSearchMessageReceivedRequestEntriesWithinRangeFDGRenderer
 	| RawSearchMessageReceivedRequestEntriesWithinRangeGaugeRenderer
 	| RawSearchMessageReceivedRequestEntriesWithinRangeHeatmapRenderer
 	| RawSearchMessageReceivedRequestEntriesWithinRangePointToPointRenderer

--- a/src/models/search/raw-search-message-received/request-entries-within-range/text-renderer.ts
+++ b/src/models/search/raw-search-message-received/request-entries-within-range/text-renderer.ts
@@ -22,7 +22,7 @@ export const isRawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer = (
 	try {
 		const t = v as RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer;
 		const entriesOK = isUndefined(t.Entries) || (isArray(t.Entries) && t.Entries.every(isRawSearchEntry));
-		const exploreOK = isUndefined(t.Entries) || (isArray(t.Explore) && t.Explore.every(isRawDataExplorerResult));
+		const exploreOK = isUndefined(t.Explore) || (isArray(t.Explore) && t.Explore.every(isRawDataExplorerResult));
 		return entriesOK && exploreOK;
 	} catch {
 		return false;

--- a/src/models/search/search-entries.ts
+++ b/src/models/search/search-entries.ts
@@ -6,6 +6,19 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
+import {
+	RawSearchMessageReceivedRequestEntriesWithinRangeChartRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeFDGRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeGaugeRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeHeatmapRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangePointmapRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangePointToPointRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeStackGraphRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeTableRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer,
+} from './raw-search-message-received';
+
 export type SearchEntries =
 	| ChartSearchEntries
 	| FDGSearchEntries
@@ -35,6 +48,21 @@ export interface ChartSearchEntries extends BaseSearchEntries {
 	}>;
 }
 
+export const normalizeToChartSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeChartRenderer,
+): ChartSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'chart',
+		names: v.Entries?.Categories ?? [],
+		data: (v.Entries?.Values ?? []).map(rawV => ({
+			timestamp: new Date(rawV.TS),
+			values: rawV.Data,
+		})),
+	};
+};
+
 export interface FDGSearchEntries extends BaseSearchEntries {
 	type: 'fdg';
 
@@ -43,6 +71,26 @@ export interface FDGSearchEntries extends BaseSearchEntries {
 	edges: Array<FDGEdge>;
 	groups: Array<string>;
 }
+
+export const normalizeToFDGSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeFDGRenderer,
+): FDGSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'fdg',
+		nodes: (v.Entries?.nodes ?? []).map(rawNode => ({
+			name: rawNode.name,
+			groupIndex: rawNode.group,
+		})),
+		edges: (v.Entries?.links ?? []).map(rawEdge => ({
+			value: rawEdge.value,
+			sourceNodeIndex: rawEdge.source,
+			targetNodeIndex: rawEdge.target,
+		})),
+		groups: v.Entries?.groups ?? [],
+	};
+};
 
 export interface FDGNode {
 	name: string;
@@ -72,12 +120,43 @@ export interface GaugeSearchEntries extends BaseSearchEntries {
 	}>;
 }
 
+export const normalizeToGaugeSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeGaugeRenderer,
+): GaugeSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'gauge',
+		data: (v.Entries ?? []).map(rawEntry => ({
+			name: rawEntry.Name,
+			magnitude: rawEntry.Magnitude,
+			min: rawEntry.Min,
+			max: rawEntry.Max,
+		})),
+	};
+};
+
 export interface HeatmapSearchEntries extends BaseSearchEntries {
 	type: 'heatmap';
 
 	// TODO
 	data: Array<MapLocation & { magnitude: number | null }>;
 }
+
+export const normalizeToHeatmapSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeHeatmapRenderer,
+): HeatmapSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'heatmap',
+		data: (v.Entries ?? []).map(rawEntry => ({
+			latitude: rawEntry.Lat,
+			longitude: rawEntry.Long,
+			magnitude: rawEntry.Magnitude ?? null,
+		})),
+	};
+};
 
 export interface PointToPointSearchEntries extends BaseSearchEntries {
 	type: 'point to point';
@@ -92,6 +171,29 @@ export interface PointToPointSearchEntries extends BaseSearchEntries {
 	}>;
 }
 
+export const normalizeToPointToPointSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangePointToPointRenderer,
+): PointToPointSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'point to point',
+		names: v.ValueNames,
+		data: (v.Entries ?? []).map(rawEntry => ({
+			source: {
+				latitude: rawEntry.Src.Lat,
+				longitude: rawEntry.Src.Long,
+			},
+			target: {
+				latitude: rawEntry.Dst.Lat,
+				longitude: rawEntry.Dst.Long,
+			},
+			magnitude: rawEntry.Magnitude ?? null,
+			values: rawEntry.Values ?? [],
+		})),
+	};
+};
+
 export interface PointmapSearchEntries extends BaseSearchEntries {
 	type: 'pointmap';
 
@@ -104,6 +206,26 @@ export interface PointmapSearchEntries extends BaseSearchEntries {
 		}>;
 	}>;
 }
+
+export const normalizeToPointmapSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangePointmapRenderer,
+): PointmapSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'pointmap',
+		data: (v.Entries ?? []).map(rawEntry => ({
+			location: {
+				latitude: rawEntry.Loc.Lat,
+				longitude: rawEntry.Loc.Long,
+			},
+			metadata: (rawEntry.Metadata ?? []).map(rawMeta => ({
+				key: rawMeta.Key,
+				value: rawMeta.Value,
+			})),
+		})),
+	};
+};
 
 export interface MapLocation {
 	latitude: number;
@@ -127,6 +249,23 @@ export interface RawSearchEntries extends BaseSearchEntries {
 	}>;
 }
 
+export const normalizeToRawSearchEntriess = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer,
+): RawSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'raw',
+		names: ['RAW'],
+		data: (v.Entries ?? []).map(rawEntry => ({
+			source: rawEntry.SRC,
+			timestamp: new Date(rawEntry.TS),
+			tag: rawEntry.Tag,
+			value: rawEntry.Data,
+		})),
+	};
+};
+
 export interface TextSearchEntries extends BaseSearchEntries {
 	type: 'text';
 
@@ -144,6 +283,23 @@ export interface TextSearchEntries extends BaseSearchEntries {
 	}>;
 }
 
+export const normalizeToTextSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer,
+): TextSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'text',
+		names: ['DATA'],
+		data: (v.Entries ?? []).map(rawEntry => ({
+			source: rawEntry.SRC,
+			timestamp: new Date(rawEntry.TS),
+			tag: rawEntry.Tag,
+			value: rawEntry.Data,
+		})),
+	};
+};
+
 export interface StackGraphSearchEntries extends BaseSearchEntries {
 	type: 'stack graph';
 
@@ -157,6 +313,23 @@ export interface StackGraphSearchEntries extends BaseSearchEntries {
 	}>;
 }
 
+export const normalizeToStackGraphSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeStackGraphRenderer,
+): StackGraphSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'stack graph',
+		data: (v.Entries ?? []).map(rawEntry => ({
+			key: rawEntry.Key,
+			values: rawEntry.Values.map(rawValue => ({
+				label: rawValue.Label,
+				value: rawValue.Value,
+			})),
+		})),
+	};
+};
+
 export interface TableSearchEntries extends BaseSearchEntries {
 	type: 'table';
 
@@ -167,3 +340,18 @@ export interface TableSearchEntries extends BaseSearchEntries {
 		values: Array<string>;
 	}>;
 }
+
+export const normalizeToTableSearchEntries = (
+	v: RawSearchMessageReceivedRequestEntriesWithinRangeTableRenderer,
+): TableSearchEntries => {
+	return {
+		start: new Date(v.EntryRange.StartTS),
+		end: new Date(v.EntryRange.EndTS),
+		type: 'table',
+		columns: v.Entries?.Columns ?? [],
+		rows: (v.Entries?.Rows ?? []).map(rawRow => ({
+			timestamp: new Date(rawRow.TS),
+			values: rawRow.Row,
+		})),
+	};
+};

--- a/src/models/search/to-search-entries.ts
+++ b/src/models/search/to-search-entries.ts
@@ -19,6 +19,16 @@ import {
 	isRawSearchMessageReceivedRequestEntriesWithinRangeTableRenderer,
 	isRawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer,
 	RawSearchMessageReceivedRequestEntriesWithinRange,
+	RawSearchMessageReceivedRequestEntriesWithinRangeChartRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeFDGRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeGaugeRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeHeatmapRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangePointmapRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangePointToPointRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeStackGraphRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeTableRenderer,
+	RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer,
 } from './raw-search-message-received';
 import {
 	normalizeToChartSearchEntries,
@@ -34,60 +44,100 @@ import {
 	SearchEntries,
 } from './search-entries';
 
-type RawEntryNormalizer = (v: RawSearchMessageReceivedRequestEntriesWithinRange) => SearchEntries | null;
+type RawEntryNormalizer = (v: RawSearchMessageReceivedRequestEntriesWithinRange) => SearchEntries;
 
 const NORMALIZERS: Record<SearchEntries['type'], RawEntryNormalizer> = {
 	'chart': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeChartRenderer(data) ? normalizeToChartSearchEntries(data) : null,
-
+		normalizeToChartSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangeChartRenderer),
 	'fdg': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeFDGRenderer(data) ? normalizeToFDGSearchEntries(data) : null,
-
+		normalizeToFDGSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangeFDGRenderer),
 	'gauge': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeGaugeRenderer(data) ? normalizeToGaugeSearchEntries(data) : null,
-
+		normalizeToGaugeSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangeGaugeRenderer),
 	'heatmap': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeHeatmapRenderer(data)
-			? normalizeToHeatmapSearchEntries(data)
-			: null,
-
+		normalizeToHeatmapSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangeHeatmapRenderer),
 	'point to point': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangePointToPointRenderer(data)
-			? normalizeToPointToPointSearchEntries(data)
-			: null,
-
+		normalizeToPointToPointSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangePointToPointRenderer),
 	'pointmap': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangePointmapRenderer(data)
-			? normalizeToPointmapSearchEntries(data)
-			: null,
-
+		normalizeToPointmapSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangePointmapRenderer),
 	'raw': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer(data) ? normalizeToRawSearchEntriess(data) : null,
-
+		normalizeToRawSearchEntriess(data as RawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer),
 	'text': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer(data) ? normalizeToTextSearchEntries(data) : null,
-
+		normalizeToTextSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer),
 	'stack graph': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeStackGraphRenderer(data)
-			? normalizeToStackGraphSearchEntries(data)
-			: null,
-
+		normalizeToStackGraphSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangeStackGraphRenderer),
 	'table': ({ data }) =>
-		isRawSearchMessageReceivedRequestEntriesWithinRangeTableRenderer(data) ? normalizeToTableSearchEntries(data) : null,
+		normalizeToTableSearchEntries(data as RawSearchMessageReceivedRequestEntriesWithinRangeTableRenderer),
 };
 
-export const toSearchEntries = (
-	rendererType: string,
+export function normalize(
+	renderer: 'chart',
 	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
-): SearchEntries => {
-	const normalizer = NORMALIZERS[rendererType as SearchEntries['type']];
+): ReturnType<typeof normalizeToChartSearchEntries>;
+export function normalize(
+	renderer: 'fdg',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToFDGSearchEntries>;
+export function normalize(
+	renderer: 'gauge',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToGaugeSearchEntries>;
+export function normalize(
+	renderer: 'heatmap',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToHeatmapSearchEntries>;
+export function normalize(
+	renderer: 'point to point',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToPointToPointSearchEntries>;
+export function normalize(
+	renderer: 'pointmap',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToPointmapSearchEntries>;
+export function normalize(
+	renderer: 'raw',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToRawSearchEntriess>;
+export function normalize(
+	renderer: 'text',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToTextSearchEntries>;
+export function normalize(
+	renderer: 'stack graph',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToStackGraphSearchEntries>;
+export function normalize(
+	renderer: 'table',
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): ReturnType<typeof normalizeToTableSearchEntries>;
+export function normalize(
+	renderer: SearchEntries['type'],
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): SearchEntries {
+	const normalizer = NORMALIZERS[renderer];
 	if (isUndefined(normalizer)) {
-		throw Error(`No such renderer type ${rendererType}`);
+		throw Error(`No such renderer type ${renderer}`);
 	}
 
 	const normalized = normalizer(msg);
 	if (isNull(normalized)) {
-		throw Error(`Bad match between renderer type "${rendererType}" and message "${JSON.stringify(msg)}".`);
+		throw Error(`Bad match between renderer type "${renderer}" and message "${JSON.stringify(msg)}".`);
+	}
+
+	return normalized;
+}
+
+export const toSearchEntries = (
+	renderer: string,
+	msg: RawSearchMessageReceivedRequestEntriesWithinRange,
+): SearchEntries => {
+	const normalizer = NORMALIZERS[renderer as SearchEntries['type']];
+	if (isUndefined(normalizer)) {
+		throw Error(`No such renderer type ${renderer}`);
+	}
+
+	const normalized = normalizer(msg);
+	if (isNull(normalized)) {
+		throw Error(`Bad match between renderer type "${renderer}" and message "${JSON.stringify(msg)}".`);
 	}
 
 	return normalized;

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,0 +1,23 @@
+/*************************************************************************
+ * Copyright 2020 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * MIT license. See the LICENSE file for details.
+ **************************************************************************/
+
+/**
+ * A delay function to use while testing.
+ *
+ * ```ts
+ * // sleep for a second
+ * await sleep(1000);
+ * ```
+ *
+ * @param ms The number of milliseconds to wait
+ */
+export const sleep = (ms: number): Promise<void> => {
+	return new Promise(resolve => {
+		setTimeout(() => resolve(), ms);
+	});
+};


### PR DESCRIPTION
Addresses #63 

Use the `renderModule` from the backend to choose which normalizer function to use on search entries.