### PR TITLE
#112 - Add confidence score to generated AX's

### DIFF
--- a/src/functions/auto-extractors/generate-auto-extractors.spec.ts
+++ b/src/functions/auto-extractors/generate-auto-extractors.spec.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { addMinutes } from 'date-fns';
-import { chain } from 'lodash';
+import { chain, isUndefined } from 'lodash';
 import { last, map, takeWhile } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 import { RawSearchEntries } from '~/models';
@@ -81,6 +81,10 @@ describe('generateAutoExtractors()', () => {
 			exploreResults['json'].forEach(ax => {
 				expect(ax.autoExtractor.tag).withContext('the suggested AX tag should match the provided tag').toEqual(tag);
 				expect(ax.autoExtractor.module).withContext('the suggested AX module should be json').toEqual('json');
+				// TODO remove this check-for-undefined when 4.1.4 hits
+				if (!isUndefined(ax.confidence)) {
+					expect(ax.confidence).withContext('json is the right module, so its confidence should be 10').toEqual(10);
+				}
 				expect(ax.autoExtractor.parameters)
 					.withContext('the suggested AX module should break out the fields in the entries')
 					.toEqual('timestamp value');
@@ -105,6 +109,10 @@ describe('generateAutoExtractors()', () => {
 					ax.explorerEntries.forEach(exploreEntry => {
 						expect(exploreEntry.elements).withContext('non-json AXes should have no elements').toEqual([]);
 					});
+					// TODO remove this check-for-undefined when 4.1.4 hits
+					if (!isUndefined(ax.confidence)) {
+						expect(ax.confidence).withContext('json is the right module, every other module should be 0').toEqual(0);
+					}
 				});
 		}),
 		25000,

--- a/src/models/auto-extractor/generated-auto-extractors.ts
+++ b/src/models/auto-extractor/generated-auto-extractors.ts
@@ -11,6 +11,7 @@ import { SearchEntry } from '../search/search-entry';
 import { AutoExtractor } from './auto-extractor';
 
 export interface GeneratedAutoExtractor {
+	confidence?: number;
 	autoExtractor: AutoExtractor;
 	entries: Array<SearchEntry>;
 	explorerEntries: Array<DataExplorerEntry>;

--- a/src/models/auto-extractor/raw-generated-auto-extrators.ts
+++ b/src/models/auto-extractor/raw-generated-auto-extrators.ts
@@ -21,6 +21,7 @@ export interface RawGeneratedAutoExtractors {
  */
 export interface RawGeneratedAutoExtractor {
 	Extractor: RawAutoExtractor;
+	Confidence?: number;
 	Entries: Array<RawSearchEntry>;
 	Explore: Array<RawDataExplorerEntry>;
 }

--- a/src/models/auto-extractor/to-generated-auto-extractor.ts
+++ b/src/models/auto-extractor/to-generated-auto-extractor.ts
@@ -17,6 +17,7 @@ export const toGeneratedAutoExtractors = (raw: RawGeneratedAutoExtractors): Gene
 	mapValues(raw, extractors =>
 		extractors.map(
 			(ex): GeneratedAutoExtractor => ({
+				confidence: ex.Confidence,
 				entries: ex.Entries.map(toSearchEntry),
 				explorerEntries: ex.Explore.map(toDataExplorerEntry),
 				autoExtractor: toAutoExtractor(ex.Extractor),


### PR DESCRIPTION
Addresses #112 

The confidence scores aren't available in 4.1.3, so I've got some checks for undefined in the test for now. When 4.1.4 hits, we can remove those.