### PR TITLE
Validate browser tests setup but don't run the actual tests for now

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -177,7 +177,7 @@ jobs:
           UNIT_TESTS: true
         run: |
           export TEST_AUTH_TOKEN="$(curl --silent --header "Content-Type:  application/json" --request POST --data '{"User":"admin","Pass":"changeme"}' http://localhost:8080/api/login | jq -r .JWT)"
-          npm run test:browsers -- --browsers=FirefoxHeadlessCI
+        # npm run test:browsers -- --browsers=FirefoxHeadlessCI
 
   test-chrome:
     runs-on: ubuntu-latest
@@ -245,4 +245,4 @@ jobs:
         run: |
           export TEST_AUTH_TOKEN="$(curl --silent --header "Content-Type:  application/json" --request POST --data '{"User":"admin","Pass":"changeme"}' http://localhost:8080/api/login | jq -r .JWT)"
           export CHROME_BIN=$(which google-chrome-stable)
-          npm run test:browsers -- --browsers=ChromeHeadlessCI
+        # npm run test:browsers -- --browsers=ChromeHeadlessCI


### PR DESCRIPTION
Browser tests are not ready and are turning our CI checks into noise.