### PR TITLE
#165 -- Test / handle invalid queries

### DIFF
--- a/src/functions/searches/initiate-search.ts
+++ b/src/functions/searches/initiate-search.ts
@@ -6,11 +6,11 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { isEmpty, isNil } from 'lodash';
-import { iif, of, throwError } from 'rxjs';
-import { concatMap, filter, first } from 'rxjs/operators';
+import { isNil } from 'lodash';
+import { defer, Observable, of, Subject, throwError } from 'rxjs';
+import { concatMap, filter, first, map, share, tap, timeoutWith, withLatestFrom } from 'rxjs/operators';
+import { v4 as uuidv4 } from 'uuid';
 import {
-	Query,
 	RawAcceptSearchMessageSent,
 	RawInitiateSearchMessageSent,
 	RawSearchInitiatedMessageReceived,
@@ -18,126 +18,131 @@ import {
 	RawSearchMessageSent,
 } from '~/models';
 import { RawJSON } from '~/value-objects';
-import { APISubscription, createProgrammaticPromise } from '../utils';
+import { APISubscription } from '../utils';
 
-interface QueryQueueTask {
-	run: () => Promise<void>;
-	isRunning: boolean;
-	isComplete: boolean;
-}
+const REQUEST_ID_METADATA_FIELD = '_requestID';
 
-class QueryQueue {
-	private _tasksByQuery: Record<Query, undefined | Array<QueryQueueTask>> = {};
+/*
+ * A queue of "requests" to initiate searches.
+ *
+ * Requests are processed one-at-a-time and in-order to mitigate race conditions
+ */
+const QUERY_QUEUE = new Subject<{
+	requestID: string;
+	rawSubscription: APISubscription<RawSearchMessageReceived, RawSearchMessageSent>;
+	query: string;
+	range: [Date, Date];
+	options: { initialFilterID?: string; metadata?: RawJSON };
+}>();
 
-	public push<T>(query: Query, fn: () => Promise<T>): Promise<T> {
-		// Create task
-		const { promise: taskPromise, resolve: resolveTask, reject: rejectTask } = createProgrammaticPromise<T>();
+/*
+ * Processes "requests" to initate searches.
+ *
+ * "Requests" are processed one-at-a-time and in-order.
+ *
+ * For each "request":
+ *   1. Set up a listener for RawSearchInitiatedMessageReceived
+ *   2. Send RawInitiateSearchMessageSent
+ *   3. Wait for listener to receive a RawSearchInitiatedMessageReceived
+ *   4. When the message is received, proceed to the next "request"
+ */
+const QUERY_INIT_RESULTS: Observable<{
+	requestID: string;
+	msg: RawSearchInitiatedMessageReceived | null;
+}> = QUERY_QUEUE.pipe(
+	// As "requests" are received, create an Observable to listen to incoming RawSearchInitiatedMessageReceived,
+	// and send a RawInitiateSearchMessageSent when ready
+	concatMap(({ requestID, rawSubscription, query, range, options }) =>
+		// Listen for incoming messages on the search websocket
+		rawSubscription.received$.pipe(
+			withLatestFrom(
+				// Wait to send RawInitiateSearchMessageSent until concatMap has subscribed to the outer Observable
+				defer(() =>
+					rawSubscription.send(<RawInitiateSearchMessageSent>{
+						type: 'search',
+						data: {
+							Addendum: options.initialFilterID ? { filterID: options.initialFilterID } : {},
+							Background: false,
+							Metadata: { ...options.metadata, [REQUEST_ID_METADATA_FIELD]: requestID }, // Include the request ID for extra safety
+							SearchStart: range[0].toISOString(),
+							SearchEnd: range[1].toISOString(),
+							SearchString: query,
+						},
+					}),
+				),
+				// Discard the (void) result from rawSubscription.send(). We only need the messages coming from received$
+				(msg: RawSearchMessageReceived) => msg,
+			),
 
-		const task: QueryQueueTask = {
-			run: async () => {
-				task.isRunning = true;
+			// Filter to only RawSearchInitiatedMessageReceived messages with the right requestID
+			filter((msg): msg is RawSearchInitiatedMessageReceived => {
 				try {
-					const result = await fn();
-					resolveTask(result);
-					task.isComplete = true;
-				} catch (err) {
-					rejectTask(err);
-					task.isComplete = true;
+					const _msg = <RawSearchInitiatedMessageReceived>msg;
+					return _msg.type === 'search' && _msg.data.Metadata[REQUEST_ID_METADATA_FIELD] === requestID;
+				} catch {
+					return false;
 				}
-			},
-			isRunning: false,
-			isComplete: false,
-		};
+			}),
 
-		// Check query tasks once that's completed
-		taskPromise
-			.then(() => {
-				return;
-			})
-			.catch(() => {
-				return;
-			})
-			.finally(() => {
-				// success or not, check the query tasks
-				this._checkQueryTasks(query);
-			});
+			// There's only one Received per Sent, so we're done after the first
+			first(),
 
-		// Insert
-		this._tasksByQuery[query] = this._tasksByQuery[query] ?? [];
-		this._tasksByQuery[query]?.push(task);
-		this._checkQueryTasks(query);
+			// Include the internal "request" ID
+			map(msg => {
+				//delete msg.data.Metadata[REQUEST_ID_METADATA_FIELD];
+				return { requestID, msg };
+			}),
 
-		return taskPromise;
-	}
+			// If the backend takes too long, we bail by emitting "null"
+			timeoutWith(
+				30000,
+				defer(() => of({ requestID, msg: null })),
+			),
+		),
+	),
+	share(),
+);
 
-	private _checkQueryTasks(query: Query): void {
-		// Remove completed tasks from queue
-		this._tasksByQuery[query] = (this._tasksByQuery[query] ?? []).filter(t => t.isComplete === false);
-		if (isEmpty(this._tasksByQuery[query])) delete this._tasksByQuery[query];
-
-		// Run next task
-		const nextInternalTask = this._tasksByQuery[query]?.[0] ?? null;
-		if (isNil(nextInternalTask)) return;
-		if (nextInternalTask.isRunning === false) nextInternalTask.run();
-	}
-}
-
-const QUERY_QUEUE = new QueryQueue();
-
-export const initiateSearch = async (
+export const initiateSearch = (
 	rawSubscription: APISubscription<RawSearchMessageReceived, RawSearchMessageSent>,
 	query: string,
 	range: [Date, Date],
 	options: { initialFilterID?: string; metadata?: RawJSON } = {},
 ): Promise<RawSearchInitiatedMessageReceived> => {
-	const task = async (): Promise<RawSearchInitiatedMessageReceived> => {
-		const searchInitMsgP = createProgrammaticPromise<RawSearchInitiatedMessageReceived>();
-		rawSubscription.received$
-			.pipe(
-				filter((msg): msg is RawSearchInitiatedMessageReceived => {
-					try {
-						const _msg = <RawSearchInitiatedMessageReceived>msg;
-						return _msg.type === 'search';
-					} catch {
-						return false;
-					}
-				}),
-				concatMap(msg =>
-					iif(
-						() => isEmpty(msg.data.Error),
-						of(msg), // If 'Error' is empty, just proceed as usual
-						throwError({ name: 'Error initiating search', message: msg.data.Error }), // If it's not empty, fail out
-					),
-				),
-				filter(msg => msg.data.RawQuery === query),
-				first(),
-			)
-			.subscribe(
-				msg => {
-					searchInitMsgP.resolve(msg);
-					rawSubscription.send(<RawAcceptSearchMessageSent>{
-						type: 'search',
-						data: { OK: true, OutputSearchSubproto: msg.data.OutputSearchSubproto },
-					});
-				},
-				err => searchInitMsgP.reject(err),
-			);
+	// Generate a unique ID for the search initiating request
+	const requestID = uuidv4();
 
-		rawSubscription.send(<RawInitiateSearchMessageSent>{
-			type: 'search',
-			data: {
-				Addendum: options.initialFilterID ? { filterID: options.initialFilterID } : {},
-				Background: false,
-				Metadata: options.metadata ?? {},
-				SearchStart: range[0].toISOString(),
-				SearchEnd: range[1].toISOString(),
-				SearchString: query,
-			},
-		});
+	// Create a promise to receive search initation results
+	const resultsP = QUERY_INIT_RESULTS.pipe(
+		// We only want results relevant to this request
+		filter(({ requestID: msgRequestID }) => msgRequestID === requestID),
 
-		const searchInitMsg = await searchInitMsgP.promise;
-		return searchInitMsg;
-	};
+		// There's only one response to the request, so we're done after the first
+		first(),
 
-	return await QUERY_QUEUE.push(query, task);
+		// If
+		concatMap(({ msg }) =>
+			isNil(msg)
+				? throwError({
+						name: 'Search Initiation Timed Out',
+						message: "Didn't receive a search initiation response from the backend in time.",
+				  })
+				: !isNil(msg.data.Error)
+				? throwError(msg)
+				: of(msg),
+		),
+
+		// If we didn't throw, everything is fine. Send a RawAcceptSearchMessageSent to continue setting up the search
+		tap(msg =>
+			rawSubscription.send(<RawAcceptSearchMessageSent>{
+				type: 'search',
+				data: { OK: true, OutputSearchSubproto: msg.data.OutputSearchSubproto },
+			}),
+		),
+	).toPromise();
+
+	// Now that we're ready to receive results (with resultsP), we can push on the queue to kick off the search initiation process
+	QUERY_QUEUE.next({ requestID, rawSubscription, query, range, options });
+
+	return resultsP;
 };

--- a/src/functions/searches/initiate-search.ts
+++ b/src/functions/searches/initiate-search.ts
@@ -87,7 +87,6 @@ const QUERY_INIT_RESULTS: Observable<{
 
 			// Include the internal "request" ID
 			map(msg => {
-				//delete msg.data.Metadata[REQUEST_ID_METADATA_FIELD];
 				return { requestID, msg };
 			}),
 
@@ -118,7 +117,9 @@ export const initiateSearch = (
 		// There's only one response to the request, so we're done after the first
 		first(),
 
-		// If
+		// If msg is null, the search initiation timed out - reject
+		// If msg.data.Error is NON-nil, the backend has a problem with the search - reject
+		// Otherwise we're good to go
 		concatMap(({ msg }) =>
 			isNil(msg)
 				? throwError({

--- a/src/functions/searches/initiate-search.ts
+++ b/src/functions/searches/initiate-search.ts
@@ -20,8 +20,6 @@ import {
 import { RawJSON } from '~/value-objects';
 import { APISubscription } from '../utils';
 
-const REQUEST_ID_METADATA_FIELD = '_requestID';
-
 /*
  * A queue of "requests" to initiate searches.
  *
@@ -63,7 +61,7 @@ const QUERY_INIT_RESULTS: Observable<{
 						data: {
 							Addendum: options.initialFilterID ? { filterID: options.initialFilterID } : {},
 							Background: false,
-							Metadata: { ...options.metadata, [REQUEST_ID_METADATA_FIELD]: requestID }, // Include the request ID for extra safety
+							Metadata: options.metadata ?? {},
 							SearchStart: range[0].toISOString(),
 							SearchEnd: range[1].toISOString(),
 							SearchString: query,
@@ -78,7 +76,7 @@ const QUERY_INIT_RESULTS: Observable<{
 			filter((msg): msg is RawSearchInitiatedMessageReceived => {
 				try {
 					const _msg = <RawSearchInitiatedMessageReceived>msg;
-					return _msg.type === 'search' && _msg.data.Metadata[REQUEST_ID_METADATA_FIELD] === requestID;
+					return _msg.type === 'search';
 				} catch {
 					return false;
 				}

--- a/src/functions/searches/initiate-search.ts
+++ b/src/functions/searches/initiate-search.ts
@@ -52,10 +52,14 @@ class QueryQueue {
 		// Check query tasks once that's completed
 		taskPromise
 			.then(() => {
-				this._checkQueryTasks(query);
+				return;
 			})
 			.catch(() => {
 				return;
+			})
+			.finally(() => {
+				// success or not, check the query tasks
+				this._checkQueryTasks(query);
 			});
 
 		// Insert

--- a/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
@@ -282,7 +282,37 @@ describe('subscribeToOneExplorerSearch()', () => {
 	);
 
 	it(
-		'Should reject bad searches without affecting good ones',
+		'Should reject bad searches without affecting good ones (different queries)',
+		integrationTest(async () => {
+			const subscribeToOneExplorerSearch = makeSubscribeToOneExplorerSearch(TEST_BASE_API_CONTEXT);
+			const range: [Date, Date] = [start, end];
+			const badRange: [Date, Date] = [start, subMinutes(start, 10)];
+			const filter: SearchFilter = { entriesOffset: { index: 0, count: count } };
+
+			// Start a bunch of search subscriptions with different queries to race them
+			await Promise.all([
+				expectAsync(subscribeToOneExplorerSearch(`tag=${tag} regex "a"`, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+				expectAsync(subscribeToOneExplorerSearch(`tag=${tag} regex "b"`, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+				expectAsync(subscribeToOneExplorerSearch(`tag=${tag} regex "c"`, range, { filter }))
+					.withContext('good query should resolve')
+					.toBeResolved(),
+				expectAsync(subscribeToOneExplorerSearch(`tag=${tag} regex "d"`, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+				expectAsync(subscribeToOneExplorerSearch(`tag=${tag} regex "e"`, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+			]);
+		}),
+		25000,
+	);
+
+	it(
+		'Should reject bad searches without affecting good ones (same query)',
 		integrationTest(async () => {
 			const subscribeToOneExplorerSearch = makeSubscribeToOneExplorerSearch(TEST_BASE_API_CONTEXT);
 			const query = `tag=${tag}`;

--- a/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
@@ -12,7 +12,7 @@ import { isArray, isUndefined, reverse, sum, zip } from 'lodash';
 import { first, last, map, takeWhile, toArray } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 import { makeCreateOneAutoExtractor } from '~/functions/auto-extractors';
-import { DataExplorerEntry, ElementFilter, isDataExplorerEntry, SearchFilter } from '~/models';
+import { DataExplorerEntry, ElementFilter, isDataExplorerEntry, SearchFilter, SearchMessageCommands } from '~/models';
 import { RawSearchEntries } from '~/models/search/search-entries';
 import { integrationTest, myCustomMatchers, sleep, TEST_BASE_API_CONTEXT } from '~/tests';
 import { makeIngestMultiLineEntry } from '../../ingestors/ingest-multi-line-entry';
@@ -308,6 +308,26 @@ describe('subscribeToOneExplorerSearch()', () => {
 					.withContext('query with bad range should reject')
 					.toBeRejected(),
 			]);
+		}),
+		25000,
+	);
+
+	it(
+		'Should send error over error$ when Last is less than First',
+		integrationTest(async () => {
+			const subscribeToOneExplorerSearch = makeSubscribeToOneExplorerSearch(TEST_BASE_API_CONTEXT);
+			const query = `tag=${tag}`;
+			const range: [Date, Date] = [start, end];
+
+			// Use an invalid filter, where Last is less than First
+			const filter: SearchFilter = { entriesOffset: { index: 1, count: -1 } };
+
+			const search = await subscribeToOneExplorerSearch(query, range, { filter });
+			const error = await search.errors$.pipe(first()).toPromise();
+
+			expect(error.data.ID).toEqual(SearchMessageCommands.ResponseError);
+			expect(error.data.Error).toBeDefined();
+			expect(error.data.Error.length).toBeGreaterThan(0);
 		}),
 		25000,
 	);

--- a/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.ts
+++ b/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { isBoolean, isEqual, isNull, isUndefined, uniqueId } from 'lodash';
+import { isBoolean, isEmpty, isEqual, isNull, isUndefined, uniqueId } from 'lodash';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { bufferCount, distinctUntilChanged, filter, map, startWith, tap } from 'rxjs/operators';
 import {
@@ -19,6 +19,7 @@ import {
 	RawRequestSearchStatsWithinRangeMessageSent,
 	RawResponseForSearchDetailsMessageReceived,
 	RawResponseForSearchStatsMessageReceived,
+	RawSearchErrorResponseReceived,
 	SearchEntries,
 	SearchFilter,
 	SearchMessageCommands,
@@ -305,12 +306,24 @@ export const makeSubscribeToOneExplorerSearch = (context: APIContext) => {
 			}),
 		);
 
+		const errors$: Observable<RawSearchErrorResponseReceived> = searchMessages$.pipe(
+			filter((msg): msg is RawSearchErrorResponseReceived => {
+				try {
+					const _msg = <RawSearchErrorResponseReceived>msg;
+					return _msg.data.ID === SearchMessageCommands.ResponseError && isEmpty(_msg.data.Error) === false;
+				} catch {
+					return false;
+				}
+			}),
+		);
+
 		return {
 			progress$,
 			entries$,
 			stats$,
 			statsOverview$,
 			statsZoom$,
+			errors$,
 			setFilter,
 			searchID: searchInitMsg.data.SearchID.toString(),
 		};

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
@@ -397,6 +397,37 @@ describe('subscribeToOneSearch()', () => {
 	);
 
 	it(
+		'Should reject bad searches without affecting good ones',
+		integrationTest(async () => {
+			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
+			const query = `tag=${tag}`;
+			const range: [Date, Date] = [start, end];
+			const badRange: [Date, Date] = [start, subMinutes(start, 10)];
+			const filter: SearchFilter = { entriesOffset: { index: 0, count: count } };
+
+			// Start a bunch of search subscriptions to race them
+			await Promise.all([
+				expectAsync(subscribeToOneSearch(query, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+				expectAsync(subscribeToOneSearch(query, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+				expectAsync(subscribeToOneSearch(query, range, { filter }))
+					.withContext('good query should resolve')
+					.toBeResolved(),
+				expectAsync(subscribeToOneSearch(query, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+				expectAsync(subscribeToOneSearch(query, badRange, { filter }))
+					.withContext('query with bad range should reject')
+					.toBeRejected(),
+			]);
+		}),
+		25000,
+	);
+
+	it(
 		'Should send error over error$ when Last is less than First',
 		integrationTest(async () => {
 			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
@@ -371,7 +371,7 @@ describe('subscribeToOneSearch()', () => {
 	);
 
 	it(
-		'Should handle a bad query string',
+		'Should reject on a bad query string',
 		integrationTest(async () => {
 			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
 			const query = `this is an invalid query`;
@@ -384,7 +384,7 @@ describe('subscribeToOneSearch()', () => {
 	);
 
 	it(
-		'Should handle a bad query range (end is before start)',
+		'Should reject on a bad query range (end is before start)',
 		integrationTest(async () => {
 			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
 			const query = `tag=${tag}`;

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
@@ -487,11 +487,22 @@ describe('subscribeToOneSearch()', () => {
 			const filter: SearchFilter = { entriesOffset: { index: 1, count: -1 } };
 
 			const search = await subscribeToOneSearch(query, range, { filter });
-			const error = await search.errors$.pipe(first()).toPromise();
 
-			expect(error.data.ID).toEqual(SearchMessageCommands.ResponseError);
-			expect(error.data.Error).toBeDefined();
-			expect(error.data.Error.length).toBeGreaterThan(0);
+			// Non-error observables should error
+			await Promise.all([
+				expectAsync(search.progress$.toPromise()).withContext('progress$ should error').toBeRejected(),
+				expectAsync(search.entries$.toPromise()).withContext('entries$ should error').toBeRejected(),
+				expectAsync(search.stats$.toPromise()).withContext('stats$ should error').toBeRejected(),
+				expectAsync(search.statsOverview$.toPromise()).withContext('statsOverview$ should error').toBeRejected(),
+				expectAsync(search.statsZoom$.toPromise()).withContext('statsZoom$ should error').toBeRejected(),
+			]);
+
+			// errors$ should emit one item (the error) and resolve
+			const error = await search.errors$.toPromise();
+
+			expect(error).toBeDefined();
+			expect(error.name.length).toBeGreaterThan(0);
+			expect(error.message.length).toBeGreaterThan(0);
 		}),
 		25000,
 	);

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
@@ -370,6 +370,32 @@ describe('subscribeToOneSearch()', () => {
 		25000,
 	);
 
+	it(
+		'Should handle a bad query string',
+		integrationTest(async () => {
+			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
+			const query = `this is an invalid query`;
+			const range: [Date, Date] = [start, end];
+			const filter: SearchFilter = { entriesOffset: { index: 0, count: count } };
+
+			await expectAsync(subscribeToOneSearch(query, range, { filter })).toBeRejected();
+		}),
+		25000,
+	);
+
+	it(
+		'Should handle a bad query range (end is before start)',
+		integrationTest(async () => {
+			const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
+			const query = `tag=${tag}`;
+			const range: [Date, Date] = [start, subMinutes(start, 10)];
+			const filter: SearchFilter = { entriesOffset: { index: 0, count: count } };
+
+			await expectAsync(subscribeToOneSearch(query, range, { filter })).toBeRejected();
+		}),
+		25000,
+	);
+
 	describe('stats', () => {
 		it(
 			'Should be evenly spread over a window matching the zoom/overview granularity',

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
@@ -6,9 +6,9 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { isBoolean, isEmpty, isEqual, isNull, isUndefined, uniqueId } from 'lodash';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
-import { bufferCount, distinctUntilChanged, filter, map, startWith, tap } from 'rxjs/operators';
+import { isBoolean, isEqual, isNull, isUndefined, uniqueId } from 'lodash';
+import { BehaviorSubject, combineLatest, NEVER, Observable, of } from 'rxjs';
+import { bufferCount, catchError, distinctUntilChanged, filter, map, skipUntil, startWith, tap } from 'rxjs/operators';
 import {
 	Query,
 	RawRequestSearchDetailsMessageSent,
@@ -17,7 +17,6 @@ import {
 	RawRequestSearchStatsWithinRangeMessageSent,
 	RawResponseForSearchDetailsMessageReceived,
 	RawResponseForSearchStatsMessageReceived,
-	RawSearchErrorResponseReceived,
 	SearchEntries,
 	SearchFilter,
 	SearchMessageCommands,
@@ -82,7 +81,16 @@ export const makeSubscribeToOneSearch = (context: APIContext) => {
 			metadata: options.metadata,
 		});
 		const searchTypeID = searchInitMsg.data.OutputSearchSubproto;
-		const searchMessages$ = rawSubscription.received$.pipe(filter(msg => msg.type === searchTypeID));
+		const isResponseError = filterMessageByCommand(SearchMessageCommands.ResponseError);
+		const searchMessages$ = rawSubscription.received$.pipe(
+			filter(msg => msg.type === searchTypeID),
+			tap(msg => {
+				// Throw if the search message command is Error
+				if (isResponseError(msg)) {
+					throw new Error(msg.data.Error);
+				}
+			}),
+		);
 		const rendererType = searchInitMsg.data.RenderModule;
 
 		const progress$: Observable<Percentage> = searchMessages$.pipe(
@@ -302,15 +310,12 @@ export const makeSubscribeToOneSearch = (context: APIContext) => {
 			}),
 		);
 
-		const errors$: Observable<RawSearchErrorResponseReceived> = searchMessages$.pipe(
-			filter((msg): msg is RawSearchErrorResponseReceived => {
-				try {
-					const _msg = <RawSearchErrorResponseReceived>msg;
-					return _msg.data.ID === SearchMessageCommands.ResponseError && isEmpty(_msg.data.Error) === false;
-				} catch {
-					return false;
-				}
-			}),
+		const errors$: Observable<Error> = searchMessages$.pipe(
+			// Skip every regular message. We only want to emit when there's an error
+			skipUntil(NEVER),
+
+			// When there's an error, catch it and emit it
+			catchError(err => of(err)),
 		);
 
 		return {

--- a/src/models/search/explorer-search-subscription.ts
+++ b/src/models/search/explorer-search-subscription.ts
@@ -8,6 +8,7 @@
 
 import { Observable } from 'rxjs';
 import { NumericID, Percentage } from '~/value-objects';
+import { RawSearchErrorResponseReceived } from './raw-search-message-received';
 import { ExplorerSearchEntries } from './search-entries';
 import { SearchFilter } from './search-filter';
 import { SearchFrequencyStats, SearchStats } from './search-stats';
@@ -15,6 +16,7 @@ import { SearchFrequencyStats, SearchStats } from './search-stats';
 export interface ExplorerSearchSubscription {
 	progress$: Observable<Percentage>;
 	entries$: Observable<ExplorerSearchEntries>;
+	errors$: Observable<RawSearchErrorResponseReceived>;
 	stats$: Observable<SearchStats>;
 	statsOverview$: Observable<{ frequencyStats: Array<SearchFrequencyStats> }>;
 	statsZoom$: Observable<{ filter?: SearchFilter; frequencyStats: Array<SearchFrequencyStats> }>;

--- a/src/models/search/explorer-search-subscription.ts
+++ b/src/models/search/explorer-search-subscription.ts
@@ -8,7 +8,6 @@
 
 import { Observable } from 'rxjs';
 import { NumericID, Percentage } from '~/value-objects';
-import { RawSearchErrorResponseReceived } from './raw-search-message-received';
 import { ExplorerSearchEntries } from './search-entries';
 import { SearchFilter } from './search-filter';
 import { SearchFrequencyStats, SearchStats } from './search-stats';
@@ -16,7 +15,7 @@ import { SearchFrequencyStats, SearchStats } from './search-stats';
 export interface ExplorerSearchSubscription {
 	progress$: Observable<Percentage>;
 	entries$: Observable<ExplorerSearchEntries>;
-	errors$: Observable<RawSearchErrorResponseReceived>;
+	errors$: Observable<Error>;
 	stats$: Observable<SearchStats>;
 	statsOverview$: Observable<{ frequencyStats: Array<SearchFrequencyStats> }>;
 	statsZoom$: Observable<{ filter?: SearchFilter; frequencyStats: Array<SearchFrequencyStats> }>;

--- a/src/models/search/raw-search-message-received/index.ts
+++ b/src/models/search/raw-search-message-received/index.ts
@@ -39,6 +39,7 @@ export interface RawSearchInitiatedMessageReceived {
 		Tags: Array<string>;
 		TimeZoomDisabled: boolean;
 		Addendum?: RawJSON;
+		Error?: string;
 	};
 }
 

--- a/src/models/search/raw-search-message-received/index.ts
+++ b/src/models/search/raw-search-message-received/index.ts
@@ -43,6 +43,14 @@ export interface RawSearchInitiatedMessageReceived {
 	};
 }
 
+export interface RawSearchErrorResponseReceived {
+	type: string; // Search subtype ID eg. "search2"
+	data: {
+		ID: SearchMessageCommands.ResponseError;
+		Error: string;
+	};
+}
+
 export interface RawResponseForSearchCloseMessageReceived {
 	type: string; // Search subtype ID eg. "search2"
 	data: { ID: SearchMessageCommands.Close; Addendum?: RawJSON };
@@ -285,6 +293,7 @@ export type RawSearchMessageReceived =
 	| RawSearchMessageReceivedRequestEntries
 	| RawSearchMessageReceivedRequestEntriesWithinRange
 	| RawSearchMessageReceivedRequestExplorerEntries
-	| RawSearchMessageReceivedRequestExplorerEntriesWithinRange;
+	| RawSearchMessageReceivedRequestExplorerEntriesWithinRange
+	| RawSearchErrorResponseReceived;
 
 export * from './request-entries-within-range';

--- a/src/models/search/search-message-commands.ts
+++ b/src/models/search/search-message-commands.ts
@@ -38,4 +38,6 @@ export enum SearchMessageCommands {
 	RequestStatsSummary = 0x7f000005, // Named REQ_STATS_GET_SUMMARY on docs
 	/** Requests current timestamp for search progress */
 	RequestStatsLocation = 0x7f000006, // Named REQ_STATS_GET_LOCATION on docs
+	/** Error response from the backend */
+	ResponseError = 0xffffffff, // Named RESP_ERROR on docs
 }

--- a/src/models/search/search-subscription.ts
+++ b/src/models/search/search-subscription.ts
@@ -8,7 +8,6 @@
 
 import { Observable } from 'rxjs';
 import { NumericID, Percentage } from '~/value-objects';
-import { RawSearchErrorResponseReceived } from './raw-search-message-received';
 import { SearchEntries } from './search-entries';
 import { SearchFilter } from './search-filter';
 import { SearchFrequencyStats, SearchStats } from './search-stats';
@@ -16,7 +15,7 @@ import { SearchFrequencyStats, SearchStats } from './search-stats';
 export interface SearchSubscription {
 	progress$: Observable<Percentage>;
 	entries$: Observable<SearchEntries>;
-	errors$: Observable<RawSearchErrorResponseReceived>;
+	errors$: Observable<Error>;
 	stats$: Observable<SearchStats>;
 	statsOverview$: Observable<{ frequencyStats: Array<SearchFrequencyStats> }>;
 	statsZoom$: Observable<{ filter?: SearchFilter; frequencyStats: Array<SearchFrequencyStats> }>;

--- a/src/models/search/search-subscription.ts
+++ b/src/models/search/search-subscription.ts
@@ -8,6 +8,7 @@
 
 import { Observable } from 'rxjs';
 import { NumericID, Percentage } from '~/value-objects';
+import { RawSearchErrorResponseReceived } from './raw-search-message-received';
 import { SearchEntries } from './search-entries';
 import { SearchFilter } from './search-filter';
 import { SearchFrequencyStats, SearchStats } from './search-stats';
@@ -15,6 +16,7 @@ import { SearchFrequencyStats, SearchStats } from './search-stats';
 export interface SearchSubscription {
 	progress$: Observable<Percentage>;
 	entries$: Observable<SearchEntries>;
+	errors$: Observable<RawSearchErrorResponseReceived>;
 	stats$: Observable<SearchStats>;
 	statsOverview$: Observable<{ frequencyStats: Array<SearchFrequencyStats> }>;
 	statsZoom$: Observable<{ filter?: SearchFilter; frequencyStats: Array<SearchFrequencyStats> }>;


### PR DESCRIPTION
This is toward #165, but it's not a complete solution for #165.

This PR tests that we're bailing out when we receive an `Error` in search initialization.