### PR TITLE
Handling of string error message

### DIFF
--- a/src/functions/utils/parse-json-response.ts
+++ b/src/functions/utils/parse-json-response.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { attempt, isString } from 'lodash';
+import {isEmpty, isString} from 'lodash';
 import { Response } from './response';
 
 type ResponseExpectation = 'void' | 'json' | 'text';
@@ -25,11 +25,16 @@ export const parseJSONResponse = async <T, Expect extends ResponseExpectation = 
 
 		if (status >= 400 && returnError === false) {
 			let error = createStatusError(status);
-			attempt(() => {
+			try {
 				const json = JSON.parse(text);
-				const errorMessage = json.Error;
+				const errorMessage = json?.Error ?? text;
 				if (isString(errorMessage)) error = new Error(errorMessage);
-			});
+			} catch (e) { // API may just return a string in the response
+				if (!isEmpty(text.trim())) {
+					error = new Error(text);
+				}
+				console.log(error)
+			}
 			throw error;
 		}
 

--- a/src/functions/utils/parse-json-response.ts
+++ b/src/functions/utils/parse-json-response.ts
@@ -33,7 +33,6 @@ export const parseJSONResponse = async <T, Expect extends ResponseExpectation = 
 				if (!isEmpty(text.trim())) {
 					error = new Error(text);
 				}
-				console.log(error)
 			}
 			throw error;
 		}


### PR DESCRIPTION
The API to update the password returns an error string, and not a JSON object so adding code to handle a situation like this so we don't have to wait for the backend to update.