### PR TITLE
Update tests

### DIFF
--- a/src/functions/auto-extractors/generate-auto-extractors.spec.ts
+++ b/src/functions/auto-extractors/generate-auto-extractors.spec.ts
@@ -7,12 +7,12 @@
  **************************************************************************/
 
 import { addMinutes } from 'date-fns';
-import { chain, isUndefined } from 'lodash';
+import { range } from 'lodash';
 import { last, map, takeWhile } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
-import { RawSearchEntries } from '~/models';
+import { CreatableJSONEntry, RawSearchEntries } from '~/models';
 import { integrationTest, sleep, TEST_BASE_API_CONTEXT } from '~/tests';
-import { makeIngestMultiLineEntry } from '../ingestors';
+import { makeIngestJSONEntries } from '../ingestors';
 import { makeSubscribeToOneSearch } from '../searches';
 import { makeGetAllTags } from '../tags';
 import { makeGenerateAutoExtractors } from './generate-auto-extractors';
@@ -39,14 +39,17 @@ describe('generateAutoExtractors()', () => {
 
 	beforeAll(async () => {
 		// Generate and ingest some entries
-		const ingestMultiLineEntry = makeIngestMultiLineEntry(TEST_BASE_API_CONTEXT);
-		const values: Array<string> = [];
-		for (let i = 0; i < count; i++) {
-			const value: Entry = { timestamp: addMinutes(start, i).toISOString(), value: i };
-			values.push(JSON.stringify(value));
-		}
-		const data: string = values.join('\n');
-		await ingestMultiLineEntry({ data, tag, assumeLocalTimezone: false });
+		const ingestJSONEntries = makeIngestJSONEntries(TEST_BASE_API_CONTEXT);
+		const values: Array<CreatableJSONEntry> = range(0, count).map(i => {
+			const timestamp = addMinutes(start, i).toISOString();
+			return {
+				timestamp,
+				tag,
+				data: JSON.stringify({ timestamp, value: i }, null, 2), // Add vertical whitespace, so that JSON is recommended over CSV
+			};
+		});
+
+		await ingestJSONEntries(values);
 
 		// Check the list of tags until our new tag appears
 		const getAllTags = makeGetAllTags(TEST_BASE_API_CONTEXT);
@@ -80,10 +83,7 @@ describe('generateAutoExtractors()', () => {
 			exploreResults['json'].forEach(ax => {
 				expect(ax.autoExtractor.tag).withContext('the suggested AX tag should match the provided tag').toEqual(tag);
 				expect(ax.autoExtractor.module).withContext('the suggested AX module should be json').toEqual('json');
-				// TODO remove this check-for-undefined when 4.1.4 hits
-				if (!isUndefined(ax.confidence)) {
-					expect(ax.confidence).withContext('json is the right module, so its confidence should be 10').toEqual(10);
-				}
+				expect(ax.confidence).withContext('json is the right module, so its confidence should be 10').toEqual(10);
 				expect(ax.autoExtractor.parameters)
 					.withContext('the suggested AX module should break out the fields in the entries')
 					.toEqual('timestamp value');
@@ -98,21 +98,7 @@ describe('generateAutoExtractors()', () => {
 				});
 			});
 
-			chain(exploreResults)
-				.omit('json') // Every AX set except 'json'
-				.values() // Just the arrays of generated AXes. We don't need the keys
-				.flatten() // Flatten the array of arrays to an array
-				.value() // Get the result
-				.forEach(ax => {
-					expect(ax.explorerEntries.length).withContext('explore should have >0 elements').toBeGreaterThan(0);
-					ax.explorerEntries.forEach(exploreEntry => {
-						expect(exploreEntry.elements).withContext('non-json AXes should have no elements').toEqual([]);
-					});
-					// TODO remove this check-for-undefined when 4.1.4 hits
-					if (!isUndefined(ax.confidence)) {
-						expect(ax.confidence).withContext('json is the right module, every other module should be 0').toEqual(0);
-					}
-				});
+			// We can't really make assertions about what the other AX generators are going to do when we look at JSON data
 		}),
 		25000,
 	);

--- a/src/functions/searches/explore-one-tag/explore-one-tag.spec.ts
+++ b/src/functions/searches/explore-one-tag/explore-one-tag.spec.ts
@@ -32,7 +32,7 @@ describe('exploreOneTag()', () => {
 	const start = new Date(2010, 0, 0);
 
 	// The end date for generated queries; one minute between each entry
-	const end = addMinutes(start, count - 1);
+	const end = addMinutes(start, count);
 
 	beforeAll(async () => {
 		// Generate and ingest some entries

--- a/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
@@ -36,7 +36,7 @@ describe('subscribeToOneExplorerSearch()', () => {
 	const start = new Date(2010, 0, 0);
 
 	// The end date for generated queries; one minute between each entry
-	const end = addMinutes(start, count - 1);
+	const end = addMinutes(start, count);
 
 	const originalData: Array<Entry> = [];
 

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
@@ -36,7 +36,7 @@ describe('subscribeToOneSearch()', () => {
 	const start = new Date(2010, 0, 0);
 
 	// The end date for generated queries; one minute between each entry
-	const end = addMinutes(start, count - 1);
+	const end = addMinutes(start, count);
 
 	const originalData: Array<Entry> = [];
 
@@ -658,7 +658,7 @@ describe('subscribeToOneSearch()', () => {
 				const subscribeToOneSearch = makeSubscribeToOneSearch(TEST_BASE_API_CONTEXT);
 				const query = `tag=${tag}`;
 				const minutes = 90;
-				const dateRange = { start, end: addMinutes(start, minutes - 1) };
+				const dateRange = { start, end: addMinutes(start, minutes) };
 				const search = await subscribeToOneSearch(query, { filter: { dateRange } });
 
 				const textEntriesP = search.entries$
@@ -744,7 +744,7 @@ describe('subscribeToOneSearch()', () => {
 				// Choose a delta that lines up nicely with the minZoomWindow buckets.
 				// The timeframe of the query is wide enough that we get a minZoomWindow > 1, which makes assertions tricky without
 				// this compensation.
-				const delta = 399;
+				const delta = 640;
 
 				// Narrow the search window by moving the end date sooner by delta minutes
 				const filter2: SearchFilter = { dateRange: { start, end: subMinutes(end, delta) } };
@@ -760,7 +760,7 @@ describe('subscribeToOneSearch()', () => {
 					.toEqual(count);
 				expect(sum(statsZoom.frequencyStats.map(x => x.count)))
 					.withContext('The sum of counts from statsZoom should be "delta" less than the total count ingested')
-					.toEqual(count - delta);
+					.toEqual(count - delta + 1); // Account for inclusive end
 				if (isUndefined(statsZoom.filter) === false) {
 					expect(statsZoom.filter)
 						.withContext(`The filter should be equal to the one used, plus the default values for undefined properties`)
@@ -903,7 +903,7 @@ describe('subscribeToOneSearch()', () => {
 				// Choose a delta that lines up nicely with the minZoomWindow buckets.
 				// The timeframe of the query is wide enough that we get a minZoomWindow > 1, which makes assertions tricky without
 				// this compensation.
-				const delta = 530;
+				const delta = 468;
 
 				// Narrow the search window by moving the end date sooner by delta minutes using new granularity
 				const newZoomGranularity = 133;
@@ -923,7 +923,7 @@ describe('subscribeToOneSearch()', () => {
 					.toEqual(count);
 				expect(sum(statsZoom.frequencyStats.map(x => x.count)))
 					.withContext('The sum of counts from statsZoom should be "delta" less than total count ingested')
-					.toEqual(count - delta);
+					.toEqual(count - delta + 1); // Account for inclusive end
 				if (isUndefined(statsZoom.filter) === false) {
 					expect(statsZoom.filter)
 						.withContext(`The filter should be equal to the one used, plus the default values for undefined properties`)
@@ -1051,7 +1051,7 @@ describe('subscribeToOneSearch()', () => {
 				// Choose a delta that lines up nicely with the minZoomWindow buckets.
 				// The timeframe of the query is wide enough that we get a minZoomWindow > 1, which makes assertions tricky without
 				// this compensation.
-				const delta = 530;
+				const delta = 468;
 
 				// Narrow the search window by moving the end date sooner by delta minutes using a new zoom granularity
 				const newZoomGranularity = 133;
@@ -1071,7 +1071,7 @@ describe('subscribeToOneSearch()', () => {
 					.toEqual(count);
 				expect(sum(statsZoom.frequencyStats.map(x => x.count)))
 					.withContext('The sum of counts from statsZoom should be "delta" less than total count ingested')
-					.toEqual(count - delta);
+					.toEqual(count - delta + 1); // Account for inclusive end
 				if (isUndefined(statsZoom.filter) === false) {
 					expect(statsZoom.filter)
 						.withContext(`The filter should be equal to the one used, plus the default values for undefined properties`)

--- a/src/models/render-module/is-render-module.ts
+++ b/src/models/render-module/is-render-module.ts
@@ -6,13 +6,13 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { isBoolean, isString } from 'lodash';
+import { isString } from 'lodash';
 import { RenderModule } from './render-module';
 
 export const isRenderModule = (value: any): value is RenderModule => {
 	try {
 		const m = <RenderModule>value;
-		return isString(m.name) && isString(m.description) && m.examples.every(isString) && isBoolean(m.sortingRequired);
+		return isString(m.name) && isString(m.description) && m.examples.every(isString);
 	} catch {
 		return false;
 	}

--- a/src/models/render-module/raw-render-module.ts
+++ b/src/models/render-module/raw-render-module.ts
@@ -10,6 +10,4 @@ export interface RawRenderModule {
 	Name: string;
 	Description: string;
 	Examples: Array<string>;
-
-	SortRequired: boolean;
 }

--- a/src/models/render-module/render-module.ts
+++ b/src/models/render-module/render-module.ts
@@ -10,6 +10,4 @@ export interface RenderModule {
 	name: string;
 	description: string;
 	examples: Array<string>;
-
-	sortingRequired: boolean;
 }

--- a/src/models/render-module/to-render-module.ts
+++ b/src/models/render-module/to-render-module.ts
@@ -13,6 +13,4 @@ export const toRenderModule = (raw: RawRenderModule): RenderModule => ({
 	name: raw.Name,
 	description: raw.Description,
 	examples: raw.Examples,
-
-	sortingRequired: raw.SortRequired,
 });


### PR DESCRIPTION
This PR fixes a handful of little bugs in the js client test suite.

Namely:

- Changes assertions about AX generators - we have way more generators now, so some of the test assumptions aren't quite right.
- Update stats/binning math now that the backend is strict about alignment
- Remove mentions of `sortingRequired` , since it's [deprecated](https://github.com/gravwell/gravwell/commit/31423ae53c74d41d920b7c5636698a0edeaed1ab)