### PR TITLE
Add logic to poll until search is finished

### DIFF
--- a/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.ts
+++ b/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.ts
@@ -7,14 +7,16 @@
  **************************************************************************/
 
 import { isAfter, subHours } from 'date-fns';
-import { isBoolean, isNull, isUndefined, uniqueId } from 'lodash';
-import { BehaviorSubject, combineLatest, from, NEVER, Observable, of, Subject, Subscription } from 'rxjs';
+import { isBoolean, isNil, isNull, isUndefined, uniqueId } from 'lodash';
+import { BehaviorSubject, combineLatest, EMPTY, from, NEVER, Observable, of, Subject, Subscription } from 'rxjs';
 import {
 	bufferCount,
 	catchError,
 	concatMap,
+	debounceTime,
 	distinctUntilChanged,
 	filter,
+	filter as rxjsFilter,
 	first,
 	map,
 	skipUntil,
@@ -267,6 +269,8 @@ export const makeSubscribeToOneExplorerSearch = (context: APIContext) => {
 				)
 				.toPromise();
 
+		let pollingSubs: Subscription;
+
 		const requestEntries = async (filter: RequiredSearchFilter): Promise<void> => {
 			if (closed) return undefined;
 
@@ -337,6 +341,50 @@ export const makeSubscribeToOneExplorerSearch = (context: APIContext) => {
 				},
 			};
 			const statsRangeP = rawSubscription.send(requestStatsWithinRangeMsg);
+
+			if (!isNil(pollingSubs)) {
+				pollingSubs.unsubscribe();
+			}
+			pollingSubs = new Subscription();
+
+			// Keep sending requests for entries until finished is true
+			pollingSubs.add(
+				entries$
+					.pipe(
+						rxjsFilter(entries => !entries.finished),
+						debounceTime(500),
+						concatMap(() => rawSubscription.send(requestEntriesMsg)),
+						catchError(() => EMPTY),
+						takeUntil(close$),
+					)
+					.subscribe(),
+			);
+
+			// Keep sending requests for stats until finished is true
+			pollingSubs.add(
+				rawSearchStats$
+					.pipe(
+						rxjsFilter(stats => !stats.data.Finished),
+						debounceTime(500),
+						concatMap(() => rawSubscription.send(requestStatsMessage)),
+						catchError(() => EMPTY),
+						takeUntil(close$),
+					)
+					.subscribe(),
+			);
+
+			// Keep sending requests for stats-within-range until finished is true
+			pollingSubs.add(
+				rawStatsZoom$
+					.pipe(
+						rxjsFilter(stats => !stats.data.Finished),
+						debounceTime(500),
+						concatMap(() => rawSubscription.send(requestStatsWithinRangeMsg)),
+						catchError(() => EMPTY),
+						takeUntil(close$),
+					)
+					.subscribe(),
+			);
 
 			await Promise.all([entriesP, statsP, detailsP, statsRangeP]);
 		};

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
@@ -299,6 +299,20 @@ export const makeSubscribeToOneSearch = (context: APIContext) => {
 			const detailsResults = await Promise.all([detailsP, detailsMsgP]);
 			const detailsMsg = detailsResults[1];
 
+			// Keep sending requests for search details until Finished is true
+			pollingSubs.add(
+				rawSearchDetails$
+					.pipe(
+						startWith(detailsMsg), // We've already received one details message - use it to start
+						rxjsFilter(details => !details.data.Finished),
+						debounceTime(500),
+						concatMap(() => rawSubscription.send(requestDetailsMsg)),
+						catchError(() => EMPTY),
+						takeUntil(close$),
+					)
+					.subscribe(),
+			);
+
 			const requestEntriesMsg: RawRequestSearchEntriesWithinRangeMessageSent = {
 				type: searchTypeID,
 				data: {


### PR DESCRIPTION
If one performs a long-running search, the client may receive a response with partial results for search entries or search stats. This PR adds polling logic, so that the search subscription will continue to emit entry/stat values until their respecitive `Finished` flag is set to true.

If `setFilter` is called before a long-running search is complete, polling is stopped and started again after filters are applied.