### PR TITLE
#252 -- fetch as an external dependency

### DIFF
--- a/src/functions/actionables/create-one-actionable.ts
+++ b/src/functions/actionables/create-one-actionable.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeCreateOneActionable = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawID = await parseJSONResponse<UUID>(raw);
 
 			const actionableID = rawID.toString();

--- a/src/functions/actionables/delete-one-actionable.ts
+++ b/src/functions/actionables/delete-one-actionable.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneActionable = (context: APIContext) => {
 	return async (actionableID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneActionable = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/actionables/get-all-actionables-as-admin.ts
+++ b/src/functions/actionables/get-all-actionables-as-admin.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Actionable, RawActionable, toActionable } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllActionablesAsAdmin = (context: APIContext) => {
 	const templatePath = '/api/pivots?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllActionablesAsAdmin = (context: APIContext) => {
 	return async (): Promise<Array<Actionable>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawActionable> | null>(raw)) ?? [];
 		return rawRes.map(toActionable);
 	};

--- a/src/functions/actionables/get-all-actionables.ts
+++ b/src/functions/actionables/get-all-actionables.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Actionable, RawActionable, toActionable } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllActionables = (context: APIContext) => {
 	const templatePath = '/api/pivots';
@@ -16,7 +16,7 @@ export const makeGetAllActionables = (context: APIContext) => {
 	return async (): Promise<Array<Actionable>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawActionable> | null>(raw)) ?? [];
 		return rawRes.map(toActionable);
 	};

--- a/src/functions/actionables/get-one-actionable.ts
+++ b/src/functions/actionables/get-one-actionable.ts
@@ -8,7 +8,7 @@
 
 import { Actionable, RawActionable, toActionable } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneActionable = (context: APIContext) => {
 	return async (actionableID: NumericID): Promise<Actionable> => {
@@ -17,7 +17,7 @@ export const makeGetOneActionable = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawActionable>(raw);
 		return toActionable(rawRes);
 	};

--- a/src/functions/actionables/update-one-actionable.ts
+++ b/src/functions/actionables/update-one-actionable.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -36,7 +35,7 @@ export const makeUpdateOneActionable = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawRes = await parseJSONResponse<RawActionable>(raw);
 			return toActionable(rawRes);
 		} catch (err) {

--- a/src/functions/auth/get-one-user-active-sessions.ts
+++ b/src/functions/auth/get-one-user-active-sessions.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawUserSessions, toUserSessions, UserSessions } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneUserActiveSessions = (context: APIContext) => {
 	return async (userID: string): Promise<UserSessions> => {
@@ -17,7 +17,7 @@ export const makeGetOneUserActiveSessions = (context: APIContext) => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
 		try {
-			const raw = await fetch(url, { ...req, method: 'GET' });
+			const raw = await context.fetch(url, { ...req, method: 'GET' });
 			const data = await parseJSONResponse<RawUserSessions>(raw);
 			return toUserSessions(data);
 		} catch (err) {

--- a/src/functions/auth/login-one-user.ts
+++ b/src/functions/auth/login-one-user.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { JWT } from '~/models';
-import { APIContext, buildHTTPRequest, buildURL, fetch, HTTPRequestOptions, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequest, buildURL, HTTPRequestOptions, parseJSONResponse } from '../utils';
 
 export const makeLoginOneUser = (context: APIContext) => {
 	const templatePath = '/api/login';
@@ -20,7 +20,7 @@ export const makeLoginOneUser = (context: APIContext) => {
 		const req = buildHTTPRequest(baseRequestOptions);
 
 		try {
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const data = await parseJSONResponse<RawResponse>(raw);
 			if (data.LoginStatus === false) throw Error(data.Reason);
 			return data.JWT;

--- a/src/functions/auth/logout-all-users.ts
+++ b/src/functions/auth/logout-all-users.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeLogoutAllUsers = (context: APIContext) => {
 	const templatePath = '/api/logout';
@@ -15,7 +15,7 @@ export const makeLogoutAllUsers = (context: APIContext) => {
 	return async (): Promise<void> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw);
 	};
 };

--- a/src/functions/auth/logout-one-user.ts
+++ b/src/functions/auth/logout-one-user.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuth, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuth, buildURL, parseJSONResponse } from '../utils';
 
 export const makeLogoutOneUser = (context: APIContext) => {
 	const templatePath = '/api/logout';
@@ -15,7 +15,7 @@ export const makeLogoutOneUser = (context: APIContext) => {
 	return async (userAuthToken: string): Promise<void> => {
 		const req = buildHTTPRequestWithAuth(userAuthToken);
 
-		const raw = await fetch(url, { ...req, method: 'PUT' });
+		const raw = await context.fetch(url, { ...req, method: 'PUT' });
 		return parseJSONResponse(raw);
 	};
 };

--- a/src/functions/auto-extractors/create-one-auto-extractor.ts
+++ b/src/functions/auto-extractors/create-one-auto-extractor.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeCreateOneAutoExtractor = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawNumericID>(raw);
 			const autoExtractorID = toNumericID(rawRes);
 

--- a/src/functions/auto-extractors/delete-one-auto-extractor.ts
+++ b/src/functions/auto-extractors/delete-one-auto-extractor.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneAutoExtractor = (context: APIContext) => {
 	return async (autoExtractorID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneAutoExtractor = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/auto-extractors/download-many-auto-extractors.ts
+++ b/src/functions/auto-extractors/download-many-auto-extractors.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { UUID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDownloadManyAutoExtractors = (context: APIContext) => {
 	return async (filter: AutoExtractorsFilter): Promise<string> => {
@@ -22,7 +22,7 @@ export const makeDownloadManyAutoExtractors = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		return await parseJSONResponse(raw, { expect: 'text' });
 	};
 };

--- a/src/functions/auto-extractors/generate-auto-extractors.ts
+++ b/src/functions/auto-extractors/generate-auto-extractors.ts
@@ -14,7 +14,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -30,7 +29,7 @@ export const makeGenerateAutoExtractors = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawGeneratedAutoExtractors>(raw);
 
 			return toGeneratedAutoExtractors(rawRes);

--- a/src/functions/auto-extractors/get-all-auto-extractor-modules.ts
+++ b/src/functions/auto-extractors/get-all-auto-extractor-modules.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { AutoExtractorModule, RawAutoExtractorModule } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllAutoExtractorModules = (context: APIContext) => {
 	const path = '/api/autoextractors/engines';
@@ -16,7 +16,7 @@ export const makeGetAllAutoExtractorModules = (context: APIContext) => {
 	return async (): Promise<Array<AutoExtractorModule>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawAutoExtractorModule> | null>(raw)) ?? [];
 		return rawRes;
 	};

--- a/src/functions/auto-extractors/get-all-auto-extractors.ts
+++ b/src/functions/auto-extractors/get-all-auto-extractors.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { AutoExtractor, RawAutoExtractor, toAutoExtractor } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllAutoExtractors = (context: APIContext) => {
 	const path = '/api/autoextractors?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllAutoExtractors = (context: APIContext) => {
 	return async (): Promise<Array<AutoExtractor>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawAutoExtractor> | null>(raw)) ?? [];
 		return rawRes.map(toAutoExtractor);
 	};

--- a/src/functions/auto-extractors/get-auto-extractors-authorized-to-me.ts
+++ b/src/functions/auto-extractors/get-auto-extractors-authorized-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { AutoExtractor, RawAutoExtractor, toAutoExtractor } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAutoExtractorsAuthorizedToMe = (context: APIContext) => {
 	const path = '/api/autoextractors';
@@ -16,7 +16,7 @@ export const makeGetAutoExtractorsAuthorizedToMe = (context: APIContext) => {
 	return async (): Promise<Array<AutoExtractor>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawAutoExtractor> | null>(raw)) ?? [];
 		return rawRes.map(toAutoExtractor);
 	};

--- a/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
+++ b/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,7 +26,7 @@ export const makeIsValidAutoExtractorSyntax = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawIsValidAutoExtractorSyntaxResponse>(raw, { returnError: true });
 			return toIsValidAutoExtractorSyntaxResponse(rawRes);
 		} catch (err) {

--- a/src/functions/auto-extractors/update-one-auto-extractor.ts
+++ b/src/functions/auto-extractors/update-one-auto-extractor.ts
@@ -17,7 +17,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -39,7 +38,7 @@ export const makeUpdateOneAutoExtractor = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawAutoExtractor = await parseJSONResponse<RawAutoExtractor>(raw);
 			return toAutoExtractor(rawAutoExtractor);
 		} catch (err) {

--- a/src/functions/auto-extractors/upload-many-auto-extractors.ts
+++ b/src/functions/auto-extractors/upload-many-auto-extractors.ts
@@ -14,7 +14,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	File,
 	HTTPRequestOptions,
 	parseJSONResponse,
@@ -36,7 +35,7 @@ export const makeUploadManyAutoExtractors = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const createdIDs = new Set(await parseJSONResponse<Array<RawUUID>>(raw));
 
 			// Only upload and return it

--- a/src/functions/dashboards/create-one-dashboard.ts
+++ b/src/functions/dashboards/create-one-dashboard.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeCreateOneDashboard = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawNumericID>(raw);
 			const dashboardID = toNumericID(rawRes);
 			return getOneDashboard(dashboardID);

--- a/src/functions/dashboards/delete-one-dashboard.ts
+++ b/src/functions/dashboards/delete-one-dashboard.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneDashboard = (context: APIContext) => {
 	return async (dashboardID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneDashboard = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/dashboards/get-all-dashboards.ts
+++ b/src/functions/dashboards/get-all-dashboards.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Dashboard, RawDashboard, toDashboard } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllDashboards = (context: APIContext) => {
 	const path = '/api/dashboards/all';
@@ -16,7 +16,7 @@ export const makeGetAllDashboards = (context: APIContext) => {
 	return async (): Promise<Array<Dashboard>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawDashboard> | null>(raw)) ?? [];
 		return rawRes.map(toDashboard);
 	};

--- a/src/functions/dashboards/get-dashboards-authorized-to-me.ts
+++ b/src/functions/dashboards/get-dashboards-authorized-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Dashboard, RawDashboard, toDashboard } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetDashboardsAuthorizedToMe = (context: APIContext) => {
 	const path = '/api/dashboards';
@@ -16,7 +16,7 @@ export const makeGetDashboardsAuthorizedToMe = (context: APIContext) => {
 	return async (): Promise<Array<Dashboard>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawDashboard> | null>(raw)) ?? [];
 		return rawRes.map(toDashboard);
 	};

--- a/src/functions/dashboards/get-dashboards-by-group.ts
+++ b/src/functions/dashboards/get-dashboards-by-group.ts
@@ -8,7 +8,7 @@
 
 import { Dashboard, RawDashboard, toDashboard } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetDashboardsByGroup = (context: APIContext) => {
 	return async (groupID: NumericID): Promise<Array<Dashboard>> => {
@@ -17,7 +17,7 @@ export const makeGetDashboardsByGroup = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawDashboard> | null>(raw)) ?? [];
 		return rawRes.map(toDashboard);
 	};

--- a/src/functions/dashboards/get-dashboards-by-user.ts
+++ b/src/functions/dashboards/get-dashboards-by-user.ts
@@ -8,7 +8,7 @@
 
 import { Dashboard, RawDashboard, toDashboard } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetDashboardsByUser = (context: APIContext) => {
 	return async (userID: NumericID): Promise<Array<Dashboard>> => {
@@ -17,7 +17,7 @@ export const makeGetDashboardsByUser = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawDashboard> | null>(raw)) ?? [];
 		return rawRes.map(toDashboard);
 	};

--- a/src/functions/dashboards/get-one-dashboard.ts
+++ b/src/functions/dashboards/get-one-dashboard.ts
@@ -8,7 +8,7 @@
 
 import { Dashboard, RawDashboard, toDashboard } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneDashboard = (context: APIContext) => {
 	return async (dashboardID: NumericID): Promise<Dashboard> => {
@@ -17,7 +17,7 @@ export const makeGetOneDashboard = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawDashboard>(raw);
 		return toDashboard(rawRes);
 	};

--- a/src/functions/dashboards/update-one-dashboard.ts
+++ b/src/functions/dashboards/update-one-dashboard.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -32,7 +31,7 @@ export const makeUpdateOneDashboard = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawDashboard = await parseJSONResponse<RawDashboard>(raw);
 			return toDashboard(rawDashboard);
 		} catch (err) {

--- a/src/functions/files/create-one-file.ts
+++ b/src/functions/files/create-one-file.ts
@@ -13,7 +13,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -34,7 +33,7 @@ export const makeCreateOneFile = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawBaseFileMetadata>(raw);
 			const globalID = rawRes.GUID;
 

--- a/src/functions/files/delete-one-file.ts
+++ b/src/functions/files/delete-one-file.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { UUID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 // !WARNING gravwell/gravwell#2505 can't use ThingUUID
 export const makeDeleteOneFile = (context: APIContext) => {
@@ -17,7 +17,7 @@ export const makeDeleteOneFile = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/files/get-all-files.ts
+++ b/src/functions/files/get-all-files.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { FileMetadata, RawFileMetadata, toFileMetadata } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllFiles = (context: APIContext) => {
 	const path = '/api/files?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllFiles = (context: APIContext) => {
 	return async (): Promise<Array<FileMetadata>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawFileMetadata> | null>(raw)) ?? [];
 		return rawRes.map(toFileMetadata);
 	};

--- a/src/functions/files/get-files-authorized-to-me.ts
+++ b/src/functions/files/get-files-authorized-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { FileMetadata, RawFileMetadata, toFileMetadata } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetFilesAuthorizedToMe = (context: APIContext) => {
 	const path = '/api/files';
@@ -16,7 +16,7 @@ export const makeGetFilesAuthorizedToMe = (context: APIContext) => {
 	return async (): Promise<Array<FileMetadata>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawFileMetadata> | null>(raw)) ?? [];
 		return rawRes.map(toFileMetadata);
 	};

--- a/src/functions/files/get-one-file-content.ts
+++ b/src/functions/files/get-one-file-content.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { UUID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneFileContent = (context: APIContext) => {
 	return async (fileID: UUID): Promise<string> => {
@@ -16,7 +16,7 @@ export const makeGetOneFileContent = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		return parseJSONResponse(raw, { expect: 'text' });
 	};
 };

--- a/src/functions/files/update-one-file.ts
+++ b/src/functions/files/update-one-file.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -46,7 +45,7 @@ export const makeUpdateOneFile = (context: APIContext) => {
 				};
 				const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-				const raw = await fetch(url, { ...req, method: 'PATCH' });
+				const raw = await context.fetch(url, { ...req, method: 'PATCH' });
 				await parseJSONResponse<RawBaseFileMetadata>(raw);
 			})();
 
@@ -63,7 +62,7 @@ export const makeUpdateOneFile = (context: APIContext) => {
 				};
 				const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-				const raw = await fetch(url, { ...req, method: 'POST' });
+				const raw = await context.fetch(url, { ...req, method: 'POST' });
 				await parseJSONResponse<RawBaseFileMetadata>(raw);
 			})();
 

--- a/src/functions/groups/add-one-user-to-many-groups.ts
+++ b/src/functions/groups/add-one-user-to-many-groups.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,7 +26,7 @@ export const makeAddOneUserToManyGroups = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/groups/create-one-group.ts
+++ b/src/functions/groups/create-one-group.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -30,7 +29,7 @@ export const makeCreateOneGroup = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawID = await parseJSONResponse<number>(raw);
 
 			const groupID = rawID.toString();

--- a/src/functions/groups/delete-one-group.ts
+++ b/src/functions/groups/delete-one-group.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneGroup = (context: APIContext) => {
 	return async (groupID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneGroup = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/groups/get-all-groups.ts
+++ b/src/functions/groups/get-all-groups.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Group, RawGroup, toGroup } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllGroups = (context: APIContext) => {
 	const templatePath = '/api/groups';
@@ -16,7 +16,7 @@ export const makeGetAllGroups = (context: APIContext) => {
 	return async (): Promise<Array<Group>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawGroup> | null>(raw)) ?? [];
 		return rawRes.map(toGroup);
 	};

--- a/src/functions/groups/get-groups-by-user.ts
+++ b/src/functions/groups/get-groups-by-user.ts
@@ -8,7 +8,7 @@
 
 import { Group, RawGroup, toGroup } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetGroupsByUser = (context: APIContext) => {
 	return async (userID: NumericID): Promise<Array<Group>> => {
@@ -17,7 +17,7 @@ export const makeGetGroupsByUser = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawGroup> | null>(raw)) ?? [];
 		return rawRes.map(toGroup);
 	};

--- a/src/functions/groups/get-one-group.ts
+++ b/src/functions/groups/get-one-group.ts
@@ -8,7 +8,7 @@
 
 import { Group, RawGroup, toGroup } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneGroup = (context: APIContext) => {
 	return async (groupID: NumericID): Promise<Group> => {
@@ -17,7 +17,7 @@ export const makeGetOneGroup = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawGroup>(raw);
 		return toGroup(rawRes);
 	};

--- a/src/functions/groups/remove-one-user-from-one-group.ts
+++ b/src/functions/groups/remove-one-user-from-one-group.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeRemoveOneUserFromOneGroup = (context: APIContext) => {
 	return async (userID: NumericID, groupID: NumericID): Promise<void> => {
@@ -17,7 +17,7 @@ export const makeRemoveOneUserFromOneGroup = (context: APIContext) => {
 		try {
 			const req = buildHTTPRequestWithAuthFromContext(context);
 
-			const raw = await fetch(url, { ...req, method: 'DELETE' });
+			const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/groups/update-one-group.ts
+++ b/src/functions/groups/update-one-group.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -30,7 +29,7 @@ export const makeUpdateOneGroup = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			await parseJSONResponse(raw, { expect: 'void' });
 			return await getOneGroup(data.id);
 		} catch (err) {

--- a/src/functions/indexers/restart-indexers.ts
+++ b/src/functions/indexers/restart-indexers.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 // TODO: Test this when gravwell/gravwell#2277 gets fixed
 export const makeRestartIndexers = (context: APIContext) => {
@@ -16,7 +16,7 @@ export const makeRestartIndexers = (context: APIContext) => {
 	return async (): Promise<void> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'POST' });
+		const raw = await context.fetch(url, { ...req, method: 'POST' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/ingestors/ingest-json-entries.ts
+++ b/src/functions/ingestors/ingest-json-entries.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,7 +26,7 @@ export const makeIngestJSONEntries = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			return parseJSONResponse(raw);
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/ingestors/ingest-multi-line-entry.ts
+++ b/src/functions/ingestors/ingest-multi-line-entry.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -28,7 +27,7 @@ export const makeIngestMultiLineEntry = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			return parseJSONResponse(raw);
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/kits/build-one-local-kit.ts
+++ b/src/functions/kits/build-one-local-kit.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -28,7 +27,7 @@ export const makeBuildOneLocalKit = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<BuildOneKitRawResponse>(raw);
 			return rawRes.UUID;
 		} catch (err) {

--- a/src/functions/kits/get-all-local-kits.ts
+++ b/src/functions/kits/get-all-local-kits.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { LocalKit, RawLocalKit, toLocalKit } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllLocalKits = (context: APIContext) => {
 	const path = '/api/kits';
@@ -16,7 +16,7 @@ export const makeGetAllLocalKits = (context: APIContext) => {
 	return async (): Promise<Array<LocalKit>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawLocalKit> | null>(raw)) ?? [];
 		return rawRes.map(toLocalKit);
 	};

--- a/src/functions/kits/get-all-remote-kits.ts
+++ b/src/functions/kits/get-all-remote-kits.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawRemoteKit, RemoteKit, toRemoteKit } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllRemoteKits = (context: APIContext) => {
 	const path = '/api/kits/remote/list';
@@ -16,7 +16,7 @@ export const makeGetAllRemoteKits = (context: APIContext) => {
 	return async (): Promise<Array<RemoteKit>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawRemoteKit> | null>(raw)) ?? [];
 		return rawRes.map(toRemoteKit);
 	};

--- a/src/functions/kits/get-one-local-kit.ts
+++ b/src/functions/kits/get-one-local-kit.ts
@@ -8,7 +8,7 @@
 
 import { LocalKit, RawLocalKit, toLocalKit } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneLocalKit = (context: APIContext) => {
 	return async (kitID: NumericID): Promise<LocalKit> => {
@@ -17,7 +17,7 @@ export const makeGetOneLocalKit = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawLocalKit>(raw);
 		return toLocalKit(rawRes);
 	};

--- a/src/functions/kits/get-one-remote-kit.ts
+++ b/src/functions/kits/get-one-remote-kit.ts
@@ -8,7 +8,7 @@
 
 import { RawRemoteKit, RemoteKit, toRemoteKit } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneRemoteKit = (context: APIContext) => {
 	return async (kitID: NumericID): Promise<RemoteKit> => {
@@ -17,7 +17,7 @@ export const makeGetOneRemoteKit = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawRemoteKit>(raw);
 		return toRemoteKit(rawRes);
 	};

--- a/src/functions/kits/install-one-kit.ts
+++ b/src/functions/kits/install-one-kit.ts
@@ -20,7 +20,6 @@ import {
 	APISubscription,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -85,7 +84,7 @@ const makeGetOneKitInstallationStatus = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawKitInstallationStatus>(raw);
 		return toKitInstallationStatus(rawRes);
 	};
@@ -102,7 +101,7 @@ const makeQueueOneKitForInstallation = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawStatusID = await parseJSONResponse<RawNumericID>(raw);
 			return toNumericID(rawStatusID);
 		} catch (err) {

--- a/src/functions/kits/uninstall-one-kit.ts
+++ b/src/functions/kits/uninstall-one-kit.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { ID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeUninstallOneKit = (context: APIContext) => {
 	return async (kitID: ID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeUninstallOneKit = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/kits/upload-one-local-kit.ts
+++ b/src/functions/kits/upload-one-local-kit.ts
@@ -13,7 +13,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	File,
 	HTTPRequestOptions,
 	parseJSONResponse,
@@ -30,7 +29,7 @@ export const makeUploadOneLocalKit = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawLocalKit>(raw);
 			return toLocalKit(rawRes);
 		} catch (err) {

--- a/src/functions/kits/upload-one-remote-kit.ts
+++ b/src/functions/kits/upload-one-remote-kit.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -28,7 +27,7 @@ export const makeUploadOneRemoteKit = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawRemoteKit>(raw);
 			return toRemoteKit(rawRes);
 		} catch (err) {

--- a/src/functions/logs/create-one-log.ts
+++ b/src/functions/logs/create-one-log.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,7 +26,7 @@ export const makeCreateOneLog = (context: APIContext) => {
 		};
 		const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-		const raw = await fetch(url, { ...req, method: 'POST' });
+		const raw = await context.fetch(url, { ...req, method: 'POST' });
 		const success = await parseJSONResponse<boolean>(raw);
 		if (!success) throw Error(`Couldn't create the log`);
 	};

--- a/src/functions/logs/get-log-levels.ts
+++ b/src/functions/logs/get-log-levels.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { LogLevels, RawLogLevels, toLogLevels } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetLogLevels = (context: APIContext) => {
 	const templatePath = '/api/logging';
@@ -16,7 +16,7 @@ export const makeGetLogLevels = (context: APIContext) => {
 	return async (): Promise<LogLevels> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawLogLevels>(raw);
 		return toLogLevels(rawRes);
 	};

--- a/src/functions/logs/set-log-level.ts
+++ b/src/functions/logs/set-log-level.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -26,7 +25,7 @@ export const makeSetLogLevel = (context: APIContext) => {
 		};
 		const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-		const raw = await fetch(url, { ...req, method: 'PUT' });
+		const raw = await context.fetch(url, { ...req, method: 'PUT' });
 		await parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/macros/create-one-macro.ts
+++ b/src/functions/macros/create-one-macro.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeCreateOneMacro = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawNumericID>(raw);
 			const macroID = toNumericID(rawRes);
 			return getOneMacro(macroID);

--- a/src/functions/macros/delete-one-macro.ts
+++ b/src/functions/macros/delete-one-macro.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneMacro = (context: APIContext) => {
 	return async (macroID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneMacro = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/macros/get-all-macros.ts
+++ b/src/functions/macros/get-all-macros.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Macro, RawMacro, toMacro } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllMacros = (context: APIContext) => {
 	const path = '/api/macros/all';
@@ -16,7 +16,7 @@ export const makeGetAllMacros = (context: APIContext) => {
 	return async (): Promise<Array<Macro>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawMacro> | null>(raw)) ?? [];
 		return rawRes.map(toMacro);
 	};

--- a/src/functions/macros/get-macros-authorized-to-me.ts
+++ b/src/functions/macros/get-macros-authorized-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Macro, RawMacro, toMacro } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetMacrosAuthorizedToMe = (context: APIContext) => {
 	const path = '/api/macros';
@@ -16,7 +16,7 @@ export const makeGetMacrosAuthorizedToMe = (context: APIContext) => {
 	return async (): Promise<Array<Macro>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawMacro> | null>(raw)) ?? [];
 		return rawRes.map(toMacro);
 	};

--- a/src/functions/macros/get-macros-by-group.ts
+++ b/src/functions/macros/get-macros-by-group.ts
@@ -8,7 +8,7 @@
 
 import { Macro, RawMacro, toMacro } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetMacrosByGroup = (context: APIContext) => {
 	return async (groupID: NumericID): Promise<Array<Macro>> => {
@@ -17,7 +17,7 @@ export const makeGetMacrosByGroup = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawMacro> | null>(raw)) ?? [];
 		return rawRes.map(toMacro);
 	};

--- a/src/functions/macros/get-macros-by-user.ts
+++ b/src/functions/macros/get-macros-by-user.ts
@@ -8,7 +8,7 @@
 
 import { Macro, RawMacro, toMacro } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetMacrosByUser = (context: APIContext) => {
 	return async (userID: NumericID): Promise<Array<Macro>> => {
@@ -17,7 +17,7 @@ export const makeGetMacrosByUser = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawMacro> | null>(raw)) ?? [];
 		return rawRes.map(toMacro);
 	};

--- a/src/functions/macros/get-one-macro.ts
+++ b/src/functions/macros/get-one-macro.ts
@@ -8,7 +8,7 @@
 
 import { Macro, RawMacro, toMacro } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneMacro = (context: APIContext) => {
 	return async (macroID: NumericID): Promise<Macro> => {
@@ -17,7 +17,7 @@ export const makeGetOneMacro = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawMacro>(raw);
 		return toMacro(rawRes);
 	};

--- a/src/functions/macros/update-one-macro.ts
+++ b/src/functions/macros/update-one-macro.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -32,7 +31,7 @@ export const makeUpdateOneMacro = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawMacro = await parseJSONResponse<RawMacro>(raw);
 			return toMacro(rawMacro);
 		} catch (err) {

--- a/src/functions/mail-server/create-server-test.ts
+++ b/src/functions/mail-server/create-server-test.ts
@@ -9,7 +9,7 @@
 import { MailServerTestData } from '~/models';
 import { isMailServerTestResult } from '~/models/mail-server/is-mail-server-test-result';
 import { MailServerTestResult } from '~/models/mail-server/mail-server-test-result';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 import { toRawMailServerTestData } from './conversion';
 import { MAIL_PATH } from './paths';
 
@@ -20,7 +20,7 @@ export const makeCreateServerTest = (context: APIContext) => {
 			const req = buildHTTPRequestWithAuthFromContext(context, {
 				body: JSON.stringify(toRawMailServerTestData(data)),
 			});
-			const rawRes = await fetch(url, { ...req, method: 'POST' });
+			const rawRes = await context.fetch(url, { ...req, method: 'POST' });
 
 			// The backend returns a JSON-encoded string
 			const result = await parseJSONResponse(rawRes);

--- a/src/functions/mail-server/get-config.ts
+++ b/src/functions/mail-server/get-config.ts
@@ -8,7 +8,7 @@
 
 import { omit } from 'lodash';
 import { MailServerConfig, RawMailServerConfig } from '../../models/mail-server';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 import { toMailServerConfig } from './conversion';
 import { MAIL_CONFIG_PATH } from './paths';
 
@@ -20,7 +20,7 @@ export const makeGetConfig = (context: APIContext) => {
 	return async (): Promise<Omit<MailServerConfig, 'password'>> => {
 		const url = buildURL(MAIL_CONFIG_PATH, { ...context, protocol: 'http' });
 		const req = buildHTTPRequestWithAuthFromContext(context);
-		const res = await fetch(url, { ...req, method: 'GET' });
+		const res = await context.fetch(url, { ...req, method: 'GET' });
 		const rawObj = await parseJSONResponse<RawMailServerConfig>(res);
 		return omit(toMailServerConfig(rawObj), 'password');
 	};

--- a/src/functions/mail-server/update-config.ts
+++ b/src/functions/mail-server/update-config.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { MailServerConfig } from '../../models/mail-server';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL } from '../utils';
 import { toRawMailServerConfig } from './conversion';
 import { MAIL_CONFIG_PATH } from './paths';
 
@@ -18,7 +18,7 @@ export const makeUpdateConfig = (context: APIContext) => {
 			const req = buildHTTPRequestWithAuthFromContext(context, {
 				body: JSON.stringify(toRawMailServerConfig(config)),
 			});
-			const rawRes = await fetch(url, { ...req, method: 'POST' });
+			const rawRes = await context.fetch(url, { ...req, method: 'POST' });
 			// The API response is empty so we just check on status
 			return rawRes.status === 200;
 		} catch (err) {

--- a/src/functions/notifications/create-one-broadcasted-notification.ts
+++ b/src/functions/notifications/create-one-broadcasted-notification.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,7 +26,7 @@ export const makeCreateOneBroadcastedNotification = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/notifications/create-one-targeted-notification.ts
+++ b/src/functions/notifications/create-one-targeted-notification.ts
@@ -16,7 +16,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 	URLOptions,
@@ -36,7 +35,7 @@ export const makeCreateOneTargetedNotification = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/notifications/delete-one-notification.ts
+++ b/src/functions/notifications/delete-one-notification.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneNotification = (context: APIContext) => async (notificationID: string): Promise<void> => {
 	const templatePath = '/api/notifications/{notificationID}';
@@ -14,6 +14,6 @@ export const makeDeleteOneNotification = (context: APIContext) => async (notific
 
 	const req = buildHTTPRequestWithAuthFromContext(context);
 
-	const raw = await fetch(url, { ...req, method: 'DELETE' });
+	const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 	return parseJSONResponse(raw, { expect: 'void' });
 };

--- a/src/functions/notifications/get-my-notifications.ts
+++ b/src/functions/notifications/get-my-notifications.ts
@@ -19,7 +19,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	omitUndefinedShallow,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeGetMyNotifications = (context: APIContext) => {
 	return async (): Promise<Array<Notification>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const rawRes = await fetch(url, { ...req, method: 'GET' });
+		const rawRes = await context.fetch(url, { ...req, method: 'GET' });
 		const rawObj = await parseJSONResponse<{ [id: string]: RawNotification }>(rawRes);
 		return Object.entries(rawObj).map<Notification>(([id, rawNotification]) => toNotification(rawNotification, id));
 	};

--- a/src/functions/notifications/update-one-notification.ts
+++ b/src/functions/notifications/update-one-notification.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeUpdateOneNotification = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/playbooks/create-one-playbook.ts
+++ b/src/functions/playbooks/create-one-playbook.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeCreateOnePlaybook = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawID = await parseJSONResponse<UUID>(raw);
 
 			const playbookID = rawID.toString();

--- a/src/functions/playbooks/delete-one-playbook.ts
+++ b/src/functions/playbooks/delete-one-playbook.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOnePlaybook = (context: APIContext) => {
 	return async (playbookID: NumericID): Promise<void> => {
@@ -15,7 +15,7 @@ export const makeDeleteOnePlaybook = (context: APIContext) => {
 		const url = buildURL(playbookPath, { ...context, protocol: 'http', pathParams: { playbookID } });
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/playbooks/get-all-playbooks-related-to-me.ts
+++ b/src/functions/playbooks/get-all-playbooks-related-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Playbook, RawPlaybook, toPlaybook } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllPlaybooksRelatedToMe = (context: APIContext) => {
 	const playbookPath = '/api/playbooks';
@@ -16,7 +16,7 @@ export const makeGetAllPlaybooksRelatedToMe = (context: APIContext) => {
 	return async (): Promise<Array<Omit<Playbook, 'body'>>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawPlaybook> | null>(raw)) ?? [];
 		return rawRes.map(p => toPlaybook(p, { includeBody: false }));
 	};

--- a/src/functions/playbooks/get-all-playbooks.ts
+++ b/src/functions/playbooks/get-all-playbooks.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Playbook, RawPlaybook, toPlaybook } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllPlaybooks = (context: APIContext) => {
 	const playbookPath = '/api/playbooks?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllPlaybooks = (context: APIContext) => {
 	return async (): Promise<Array<Omit<Playbook, 'body'>>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawPlaybook> | null>(raw)) ?? [];
 		return rawRes.map(p => toPlaybook(p, { includeBody: false }));
 	};

--- a/src/functions/playbooks/get-one-playbook.ts
+++ b/src/functions/playbooks/get-one-playbook.ts
@@ -8,7 +8,7 @@
 
 import { Playbook, RawPlaybook, toPlaybook } from '~/models';
 import { UUID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOnePlaybook = (context: APIContext) => {
 	return async (playbookID: UUID): Promise<Playbook> => {
@@ -17,7 +17,7 @@ export const makeGetOnePlaybook = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawPlaybook>(raw);
 		return toPlaybook(rawRes);
 	};

--- a/src/functions/playbooks/update-one-playbook.ts
+++ b/src/functions/playbooks/update-one-playbook.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -37,7 +36,7 @@ export const makeUpdateOnePlaybook = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawRes = await parseJSONResponse<RawPlaybook>(raw);
 			return toPlaybook(rawRes);
 		} catch (err) {

--- a/src/functions/render-modules/get-all-render-modules.ts
+++ b/src/functions/render-modules/get-all-render-modules.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawRenderModule, RenderModule, toRenderModule } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllRenderModules = (context: APIContext) => {
 	const templatePath = '/api/info/rendermodules';
@@ -16,7 +16,7 @@ export const makeGetAllRenderModules = (context: APIContext) => {
 	return async (): Promise<Array<RenderModule>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<RawResponse>(raw)) ?? [];
 		return rawRes.map(toRenderModule);
 	};

--- a/src/functions/resources/create-one-resource.ts
+++ b/src/functions/resources/create-one-resource.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,7 +26,7 @@ export const makeCreateOneResource = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawResource>(raw);
 			return toResource(rawRes);
 		} catch (err) {

--- a/src/functions/resources/delete-one-resource.ts
+++ b/src/functions/resources/delete-one-resource.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneResource = (context: APIContext) => {
 	return async (resourceID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneResource = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/resources/get-all-resources.ts
+++ b/src/functions/resources/get-all-resources.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawResource, Resource, toResource } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllResources = (context: APIContext) => {
 	const resourcePath = '/api/resources?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllResources = (context: APIContext) => {
 	return async (): Promise<Array<Omit<Resource, 'body'>>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawResource> | null>(raw)) ?? [];
 		return rawRes.map(toResource);
 	};

--- a/src/functions/resources/get-one-resource-content.ts
+++ b/src/functions/resources/get-one-resource-content.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { ID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneResourceContent = (context: APIContext) => {
 	return async (resourceID: ID): Promise<string> => {
@@ -16,7 +16,7 @@ export const makeGetOneResourceContent = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		return await parseJSONResponse(raw, { expect: 'text' });
 	};
 };

--- a/src/functions/resources/get-one-resource.ts
+++ b/src/functions/resources/get-one-resource.ts
@@ -8,7 +8,7 @@
 
 import { isBlankRawResource, RawResource, Resource, toResource } from '~/models';
 import { UUID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneResource = (context: APIContext) => {
 	return async (resourceID: UUID): Promise<Resource> => {
@@ -17,7 +17,7 @@ export const makeGetOneResource = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawResource = await parseJSONResponse<RawResource>(raw);
 		// gravwell/gravwell#2337 nº 3
 		if (isBlankRawResource(rawResource)) throw new Error('Not found');

--- a/src/functions/resources/get-resources-authorized-to-me.ts
+++ b/src/functions/resources/get-resources-authorized-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawResource, Resource, toResource } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetResourcesAuthorizedToMe = (context: APIContext) => {
 	const resourcePath = '/api/resources';
@@ -16,7 +16,7 @@ export const makeGetResourcesAuthorizedToMe = (context: APIContext) => {
 	return async (): Promise<Array<Omit<Resource, 'body'>>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawResources = (await parseJSONResponse<Array<RawResource> | null>(raw)) ?? [];
 		return rawResources.map(toResource);
 	};

--- a/src/functions/resources/preview-one-resource-content.ts
+++ b/src/functions/resources/preview-one-resource-content.ts
@@ -8,7 +8,7 @@
 
 import { RawResourceContentPreview, ResourceContentPreview, toResourceContentPreview } from '~/models';
 import { UUID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makePreviewOneResourceContent = (context: APIContext) => {
 	return async (resourceID: UUID, options: { bytes?: number } = {}): Promise<ResourceContentPreview> => {
@@ -22,7 +22,7 @@ export const makePreviewOneResourceContent = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawPreview = await parseJSONResponse<RawResourceContentPreview>(raw);
 		return toResourceContentPreview(rawPreview);
 	};

--- a/src/functions/resources/set-one-resource-content.ts
+++ b/src/functions/resources/set-one-resource-content.ts
@@ -14,7 +14,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	File,
 	HTTPRequestOptions,
 	parseJSONResponse,
@@ -31,7 +30,7 @@ export const makeSetOneResourceContent = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawRes = await parseJSONResponse<RawResource>(raw);
 			return toResource(rawRes);
 		} catch (err) {

--- a/src/functions/resources/update-one-resource.ts
+++ b/src/functions/resources/update-one-resource.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -43,7 +42,8 @@ export const makeUpdateOneResource = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const metadataP = fetch(url, { ...req, method: 'PUT' })
+			const metadataP = context
+				.fetch(url, { ...req, method: 'PUT' })
 				.then(res => parseJSONResponse<RawResource>(res))
 				.then(toResource)
 				.then(insertResource);

--- a/src/functions/saved-queries/create-one-saved-query.ts
+++ b/src/functions/saved-queries/create-one-saved-query.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,7 +26,7 @@ export const makeCreateOneSavedQuery = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawRes = await parseJSONResponse<RawSavedQuery>(raw);
 			return toSavedQuery(rawRes);
 		} catch (err) {

--- a/src/functions/saved-queries/delete-one-saved-query.ts
+++ b/src/functions/saved-queries/delete-one-saved-query.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneSavedQuery = (context: APIContext) => {
 	return async (savedQueryID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneSavedQuery = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/saved-queries/get-all-saved-queries.ts
+++ b/src/functions/saved-queries/get-all-saved-queries.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawSavedQuery, SavedQuery, toSavedQuery } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllSavedQueries = (context: APIContext) => {
 	const path = '/api/library?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllSavedQueries = (context: APIContext) => {
 	return async (): Promise<Array<SavedQuery>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawSavedQuery> | null>(raw)) ?? [];
 		return rawRes.map(toSavedQuery);
 	};

--- a/src/functions/saved-queries/get-one-saved-query.ts
+++ b/src/functions/saved-queries/get-one-saved-query.ts
@@ -8,7 +8,7 @@
 
 import { RawSavedQuery, SavedQuery, toSavedQuery } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneSavedQuery = (context: APIContext) => {
 	return async (savedQueryID: NumericID): Promise<SavedQuery> => {
@@ -17,7 +17,7 @@ export const makeGetOneSavedQuery = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawSavedQuery>(raw);
 		return toSavedQuery(rawRes);
 	};

--- a/src/functions/saved-queries/get-saved-queries-authorized-to-me.ts
+++ b/src/functions/saved-queries/get-saved-queries-authorized-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawSavedQuery, SavedQuery, toSavedQuery } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetSavedQueriesAuthorizedToMe = (context: APIContext) => {
 	const path = '/api/library';
@@ -16,7 +16,7 @@ export const makeGetSavedQueriesAuthorizedToMe = (context: APIContext) => {
 	return async (): Promise<Array<SavedQuery>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawSavedQuery> | null>(raw)) ?? [];
 		return rawRes.map(toSavedQuery);
 	};

--- a/src/functions/saved-queries/update-one-saved-query.ts
+++ b/src/functions/saved-queries/update-one-saved-query.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -32,7 +31,7 @@ export const makeUpdateOneSavedQuery = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawSavedQuery = await parseJSONResponse<RawSavedQuery>(raw);
 			return toSavedQuery(rawSavedQuery);
 		} catch (err) {

--- a/src/functions/scheduled-tasks/clear-one-scheduled-task-error.ts
+++ b/src/functions/scheduled-tasks/clear-one-scheduled-task-error.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeClearOneScheduledTaskError = (context: APIContext) => {
 	return async (scheduledTaskID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeClearOneScheduledTaskError = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/scheduled-tasks/clear-one-scheduled-task-state.ts
+++ b/src/functions/scheduled-tasks/clear-one-scheduled-task-state.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeClearOneScheduledTaskState = (context: APIContext) => {
 	return async (scheduledTaskID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeClearOneScheduledTaskState = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/scheduled-tasks/create-one-scheduled-task.ts
+++ b/src/functions/scheduled-tasks/create-one-scheduled-task.ts
@@ -18,7 +18,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -41,7 +40,7 @@ export const makeCreateOneScheduledTask = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawID = await parseJSONResponse<RawNumericID>(raw);
 			const scheduledTaskID = toNumericID(rawID);
 

--- a/src/functions/scheduled-tasks/delete-one-scheduled-task.ts
+++ b/src/functions/scheduled-tasks/delete-one-scheduled-task.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneScheduledTask = (context: APIContext) => {
 	return async (scheduledTaskID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneScheduledTask = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/scheduled-tasks/delete-scheduled-tasks-by-user.ts
+++ b/src/functions/scheduled-tasks/delete-scheduled-tasks-by-user.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteScheduledTasksByUser = (context: APIContext) => {
 	return async (userID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteScheduledTasksByUser = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/scheduled-tasks/get-all-scheduled-tasks.ts
+++ b/src/functions/scheduled-tasks/get-all-scheduled-tasks.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawScheduledTask, ScheduledTask, toScheduledTask } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllScheduledTasks = (context: APIContext) => {
 	const path = '/api/scheduledsearches?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllScheduledTasks = (context: APIContext) => {
 	return async (): Promise<Array<ScheduledTask>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawScheduledTask> | null>(raw)) ?? [];
 		return rawRes.map(toScheduledTask);
 	};

--- a/src/functions/scheduled-tasks/get-one-scheduled-task.ts
+++ b/src/functions/scheduled-tasks/get-one-scheduled-task.ts
@@ -15,7 +15,7 @@ import {
 	toScheduledTask,
 } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneScheduledTask = (context: APIContext) => {
 	return async <Type extends ScheduledTaskType = ScheduledTaskType>(
@@ -26,7 +26,7 @@ export const makeGetOneScheduledTask = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawScheduledTask>(raw);
 
 		const task: ScheduledTask = await toScheduledTask(rawRes);

--- a/src/functions/scheduled-tasks/get-scheduled-tasks-authorized-to-me.ts
+++ b/src/functions/scheduled-tasks/get-scheduled-tasks-authorized-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawScheduledTask, ScheduledTask, toScheduledTask } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetScheduledTasksAuthorizedToMe = (context: APIContext) => {
 	const path = '/api/scheduledsearches';
@@ -16,7 +16,7 @@ export const makeGetScheduledTasksAuthorizedToMe = (context: APIContext) => {
 	return async (): Promise<Array<ScheduledTask>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawScheduledTask> | null>(raw)) ?? [];
 		return rawRes.map(toScheduledTask);
 	};

--- a/src/functions/scheduled-tasks/get-scheduled-tasks-by-user.ts
+++ b/src/functions/scheduled-tasks/get-scheduled-tasks-by-user.ts
@@ -8,7 +8,7 @@
 
 import { RawScheduledTask, ScheduledTask, toScheduledTask } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetScheduledTasksByUser = (context: APIContext) => {
 	return async (userID: NumericID): Promise<Array<ScheduledTask>> => {
@@ -17,7 +17,7 @@ export const makeGetScheduledTasksByUser = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawScheduledTask> | null>(raw)) ?? [];
 		return rawRes.map(toScheduledTask);
 	};

--- a/src/functions/scheduled-tasks/update-one-scheduled-task.ts
+++ b/src/functions/scheduled-tasks/update-one-scheduled-task.ts
@@ -19,7 +19,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -44,7 +43,7 @@ export const makeUpdateOneScheduledTask = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawScheduledTask = await parseJSONResponse<RawScheduledTask>(raw);
 
 			const task: ScheduledTask = toScheduledTask(rawScheduledTask);

--- a/src/functions/scripts/get-one-script-library.ts
+++ b/src/functions/scripts/get-one-script-library.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Script } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneScriptLibrary = (context: APIContext) => {
 	return async (path: string, options: { repository?: string; commitID?: string } = {}): Promise<Script> => {
@@ -20,7 +20,7 @@ export const makeGetOneScriptLibrary = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		return parseJSONResponse(raw, { expect: 'text' });
 	};
 };

--- a/src/functions/scripts/sync-all-script-libraries.ts
+++ b/src/functions/scripts/sync-all-script-libraries.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeSyncAllScriptLibraries = (context: APIContext) => {
 	const templatePath = '/api/libs/pull';
@@ -15,7 +15,7 @@ export const makeSyncAllScriptLibraries = (context: APIContext) => {
 	return async (): Promise<void> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/scripts/validate-one-script.ts
+++ b/src/functions/scripts/validate-one-script.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -26,7 +25,7 @@ export const makeValidateOneScript = (context: APIContext) => {
 		};
 		const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-		const raw = await fetch(url, { ...req, method: 'PUT' });
+		const raw = await context.fetch(url, { ...req, method: 'PUT' });
 		const rawRes = await parseJSONResponse<RawValidatedScript>(raw);
 		return toValidatedScript(rawRes);
 	};

--- a/src/functions/search-groups/get-one-user-search-group.ts
+++ b/src/functions/search-groups/get-one-user-search-group.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneUserSearchGroup = (context: APIContext) => {
 	return async (userID: NumericID): Promise<NumericID> => {
@@ -17,7 +17,7 @@ export const makeGetOneUserSearchGroup = (context: APIContext) => {
 
 			const req = buildHTTPRequestWithAuthFromContext(context);
 
-			const raw = await fetch(url, { ...req, method: 'GET' });
+			const raw = await context.fetch(url, { ...req, method: 'GET' });
 			const parsed = await parseJSONResponse<NumericID>(raw);
 			return parsed.toString(); // backend returns an int
 		} catch (err) {

--- a/src/functions/search-groups/update-one-user-search-group.ts
+++ b/src/functions/search-groups/update-one-user-search-group.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	omitUndefinedShallow,
 	parseJSONResponse,
@@ -33,7 +32,7 @@ export const makeUpdateOneUserSearchGroup = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/search-modules/get-all-search-modules.ts
+++ b/src/functions/search-modules/get-all-search-modules.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawSearchModule, SearchModule, toSearchModule } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllSearchModules = (context: APIContext) => {
 	const templatePath = '/api/info/searchmodules';
@@ -16,7 +16,7 @@ export const makeGetAllSearchModules = (context: APIContext) => {
 	return async (): Promise<Array<SearchModule>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<RawResponse>(raw)) ?? [];
 		return rawRes.map(toSearchModule);
 	};

--- a/src/functions/searches/background-one-search.ts
+++ b/src/functions/searches/background-one-search.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeBackgroundOneSearch = (context: APIContext) => {
 	return async (searchID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeBackgroundOneSearch = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'PATCH' });
+		const raw = await context.fetch(url, { ...req, method: 'PATCH' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/searches/delete-one-search.ts
+++ b/src/functions/searches/delete-one-search.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneSearch = (context: APIContext) => {
 	return async (searchID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneSearch = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/searches/get-all-persistent-search-status.ts
+++ b/src/functions/searches/get-all-persistent-search-status.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawSearch2, Search2, toSearch2 } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllPersistentSearchStatus = (context: APIContext) => {
 	const templatePath = '/api/searchctrl/all';
@@ -16,7 +16,7 @@ export const makeGetAllPersistentSearchStatus = (context: APIContext) => {
 	return async (): Promise<Array<Search2>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<RawResponse>(raw)) ?? [];
 		return rawRes.map(toSearch2);
 	};

--- a/src/functions/searches/get-one-persistent-search-status.ts
+++ b/src/functions/searches/get-one-persistent-search-status.ts
@@ -8,7 +8,7 @@
 
 import { RawSearch2, Search2, toSearch2 } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOnePersistentSearchStatus = (context: APIContext) => {
 	return async (searchID: NumericID): Promise<Search2> => {
@@ -17,7 +17,7 @@ export const makeGetOnePersistentSearchStatus = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawSearch2>(raw);
 		return toSearch2(rawRes);
 	};

--- a/src/functions/searches/get-persistent-search-status-related-to-me.ts
+++ b/src/functions/searches/get-persistent-search-status-related-to-me.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawSearch2, Search2, toSearch2 } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetPersistentSearchStatusRelatedToMe = (context: APIContext) => {
 	const templatePath = '/api/searchctrl';
@@ -16,7 +16,7 @@ export const makeGetPersistentSearchStatusRelatedToMe = (context: APIContext) =>
 	return async (): Promise<Array<Search2>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<RawResponse>(raw)) ?? [];
 		return rawRes.map(toSearch2);
 	};

--- a/src/functions/searches/get-search-history.ts
+++ b/src/functions/searches/get-search-history.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawSearch, Search, toSearch } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetSearchHistory = (context: APIContext) => {
 	return async (filter: SearchHistoryFilter): Promise<Array<Search>> => {
@@ -39,7 +39,7 @@ export const makeGetSearchHistory = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawSearches = (await parseJSONResponse<Array<RawSearch> | null>(raw)) ?? [];
 		return rawSearches.map(toSearch);
 	};

--- a/src/functions/searches/save-one-search.ts
+++ b/src/functions/searches/save-one-search.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeSaveOneSearch = (context: APIContext) => {
 	return async (searchID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeSaveOneSearch = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'PATCH' });
+		const raw = await context.fetch(url, { ...req, method: 'PATCH' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/searches/stop one-search.ts
+++ b/src/functions/searches/stop one-search.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL } from '../utils';
 
 export const makeStopOneSearch = (context: APIContext) => {
 	return async (searchID: NumericID): Promise<void> => {
@@ -16,6 +16,6 @@ export const makeStopOneSearch = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		await fetch(url, { ...req, method: 'PUT' });
+		await context.fetch(url, { ...req, method: 'PUT' });
 	};
 };

--- a/src/functions/system/backup.ts
+++ b/src/functions/system/backup.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL } from '../utils';
 
 export const makeBackup = (context: APIContext) => {
 	const templatePath = '/api/backup';
@@ -20,7 +20,7 @@ export const makeBackup = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 
 		const matches = raw.headers.get('content-disposition')?.match(/^attachment; filename="(?<name>.*)"$/);
 		const filename = matches?.groups?.name ?? 'GravwellBackup.gravbak';

--- a/src/functions/system/get-api-version.ts
+++ b/src/functions/system/get-api-version.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Version } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAPIVersion = (context: APIContext) => {
 	const templatePath = '/api/version/';
@@ -16,7 +16,7 @@ export const makeGetAPIVersion = (context: APIContext) => {
 	return async (): Promise<GetAPIVersionResponse> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<GetAPIVersionRawResponse>(raw);
 		return toGetAPIVersionResponse(rawRes);
 	};

--- a/src/functions/system/get-system-settings.ts
+++ b/src/functions/system/get-system-settings.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawSystemSettings, SystemSettings, toSystemSettings } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetSystemSettings = (context: APIContext) => {
 	const templatePath = '/api/settings';
@@ -16,7 +16,7 @@ export const makeGetSystemSettings = (context: APIContext) => {
 	return async (): Promise<SystemSettings> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawSystemSettings>(raw);
 		return toSystemSettings(rawRes);
 	};

--- a/src/functions/system/restore.ts
+++ b/src/functions/system/restore.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import * as FormData from 'form-data';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, File, HTTPRequestOptions } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, File, HTTPRequestOptions } from '../utils';
 
 export const makeRestore = (context: APIContext) => {
 	const templatePath = '/api/backup';
@@ -21,6 +21,6 @@ export const makeRestore = (context: APIContext) => {
 			body: form as any,
 		};
 		const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
-		await fetch(url, { ...req, method: 'POST', signal });
+		await context.fetch(url, { ...req, method: 'POST', signal });
 	};
 };

--- a/src/functions/system/subscribe-to-many-system-informations.spec.ts
+++ b/src/functions/system/subscribe-to-many-system-informations.spec.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { integrationTest, TEST_AUTH_TOKEN, TEST_BASE_API_CONTEXT, unitTest } from '~/tests';
+import { integrationTest, TEST_BASE_API_CONTEXT, unitTest } from '~/tests';
 import { makeSubscribeToManySystemInformations } from './subscribe-to-many-system-informations';
 
 const wait = (n: number) => new Promise(resolve => setTimeout(resolve, n));
@@ -17,12 +17,7 @@ describe('subscribeToManySystemInformations()', () => {
 	it(
 		'Should return a function given a valid host',
 		unitTest(() => {
-			const fn = () =>
-				makeSubscribeToManySystemInformations({
-					host: 'www.example.com',
-					useEncryption: false,
-					authToken: TEST_AUTH_TOKEN,
-				});
+			const fn = () => makeSubscribeToManySystemInformations({ ...TEST_BASE_API_CONTEXT, host: 'www.example.com' });
 			expect(fn).not.toThrow();
 			expect(typeof fn()).toBe('function');
 		}),

--- a/src/functions/system/system-is-connected.ts
+++ b/src/functions/system/system-is-connected.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeSystemIsConnected = (context: APIContext) => {
 	const templatePath = '/api/test';
@@ -16,7 +16,7 @@ export const makeSystemIsConnected = (context: APIContext) => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
 		try {
-			const rawRes = await fetch(url, { ...req, method: 'GET' });
+			const rawRes = await context.fetch(url, { ...req, method: 'GET' });
 			await parseJSONResponse(rawRes, { expect: 'void' });
 			return true;
 		} catch {

--- a/src/functions/tags/get-all-tags.spec.ts
+++ b/src/functions/tags/get-all-tags.spec.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { integrationTest, TEST_AUTH_TOKEN, TEST_BASE_API_CONTEXT, unitTest } from '~/tests';
+import { integrationTest, TEST_BASE_API_CONTEXT, unitTest } from '~/tests';
 import { makeGetAllTags } from './get-all-tags';
 
 describe('getAllTags()', () => {
@@ -15,7 +15,7 @@ describe('getAllTags()', () => {
 	it(
 		'Should return a function given a valid host',
 		unitTest(() => {
-			const fn = () => makeGetAllTags({ host: 'www.example.com', useEncryption: false, authToken: TEST_AUTH_TOKEN });
+			const fn = () => makeGetAllTags({ ...TEST_BASE_API_CONTEXT, host: 'www.example.com' });
 			expect(fn).not.toThrow();
 			expect(typeof fn()).toBe('function');
 		}),

--- a/src/functions/tags/get-all-tags.ts
+++ b/src/functions/tags/get-all-tags.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { Tag } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllTags = (context: APIContext) => {
 	const templatePath = '/api/tags';
@@ -16,7 +16,7 @@ export const makeGetAllTags = (context: APIContext) => {
 	return async (): Promise<Array<Tag>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		return parseJSONResponse(raw);
 	};
 };

--- a/src/functions/templates/create-one-template.ts
+++ b/src/functions/templates/create-one-template.ts
@@ -12,7 +12,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -31,7 +30,7 @@ export const makeCreateOneTemplate = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawID = await parseJSONResponse<UUID>(raw);
 
 			const templateID = rawID.toString();

--- a/src/functions/templates/delete-one-template.ts
+++ b/src/functions/templates/delete-one-template.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneTemplate = (context: APIContext) => {
 	return async (templateID: NumericID): Promise<void> => {
@@ -16,7 +16,7 @@ export const makeDeleteOneTemplate = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/templates/get-all-templates-as-admin.ts
+++ b/src/functions/templates/get-all-templates-as-admin.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawTemplate, Template, toTemplate } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllTemplatesAsAdmin = (context: APIContext) => {
 	const templatePath = '/api/templates?admin=true';
@@ -16,7 +16,7 @@ export const makeGetAllTemplatesAsAdmin = (context: APIContext) => {
 	return async (): Promise<Array<Template>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawTemplate> | null>(raw)) ?? [];
 		return rawRes.map(toTemplate);
 	};

--- a/src/functions/templates/get-all-templates.ts
+++ b/src/functions/templates/get-all-templates.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawTemplate, Template, toTemplate } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllTemplates = (context: APIContext) => {
 	const templatePath = '/api/templates';
@@ -16,7 +16,7 @@ export const makeGetAllTemplates = (context: APIContext) => {
 	return async (): Promise<Array<Template>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawTemplate> | null>(raw)) ?? [];
 		return rawRes.map(toTemplate);
 	};

--- a/src/functions/templates/get-one-template.ts
+++ b/src/functions/templates/get-one-template.ts
@@ -8,7 +8,7 @@
 
 import { RawTemplate, Template, toTemplate } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneTemplate = (context: APIContext) => {
 	return async (templateID: NumericID): Promise<Template> => {
@@ -17,7 +17,7 @@ export const makeGetOneTemplate = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawTemplate>(raw);
 		return toTemplate(rawRes);
 	};

--- a/src/functions/templates/update-one-template.ts
+++ b/src/functions/templates/update-one-template.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -36,7 +35,7 @@ export const makeUpdateOneTemplate = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			const rawRes = await parseJSONResponse<RawTemplate>(raw);
 			return toTemplate(rawRes);
 		} catch (err) {

--- a/src/functions/user-preferences/delete-one-user-preferences.ts
+++ b/src/functions/user-preferences/delete-one-user-preferences.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneUserPreferences = (context: APIContext) => async (userID: string): Promise<void> => {
 	const templatePath = '/api/users/{userID}/preferences';
@@ -14,6 +14,6 @@ export const makeDeleteOneUserPreferences = (context: APIContext) => async (user
 
 	const req = buildHTTPRequestWithAuthFromContext(context);
 
-	const raw = await fetch(url, { ...req, method: 'DELETE' });
+	const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 	return parseJSONResponse(raw);
 };

--- a/src/functions/user-preferences/get-all-user-preferences.ts
+++ b/src/functions/user-preferences/get-all-user-preferences.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawUserPreferencesWithMetadata, toUserPreferencesWithMetadata, UserPreferencesWithMetadata } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllUserPreferences = (context: APIContext) => {
 	const templatePath = '/api/users/preferences';
@@ -16,7 +16,7 @@ export const makeGetAllUserPreferences = (context: APIContext) => {
 	return async (): Promise<Array<UserPreferencesWithMetadata>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = ((await parseJSONResponse<Array<RawUserPreferencesWithMetadata> | null>(raw)) ?? []).filter(
 			// There are other things that come here, like email preferences for example. We need to make sure we're only getting the user preferences
 			v => v.Name === 'prefs',

--- a/src/functions/user-preferences/get-one-user-preferences.ts
+++ b/src/functions/user-preferences/get-one-user-preferences.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { UserPreferences } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneUserPreferences = (context: APIContext) => async (userID: string): Promise<UserPreferences> => {
 	const templatePath = '/api/users/{userID}/preferences';
@@ -15,6 +15,6 @@ export const makeGetOneUserPreferences = (context: APIContext) => async (userID:
 
 	const req = buildHTTPRequestWithAuthFromContext(context);
 
-	const raw = await fetch(url, { ...req, method: 'GET' });
+	const raw = await context.fetch(url, { ...req, method: 'GET' });
 	return parseJSONResponse(raw);
 };

--- a/src/functions/user-preferences/update-one-user-preferences.ts
+++ b/src/functions/user-preferences/update-one-user-preferences.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -27,6 +26,6 @@ export const makeUpdateOneUserPreferences = (context: APIContext) => async (
 	};
 	const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-	const raw = await fetch(url, { ...req, method: 'PUT' });
+	const raw = await context.fetch(url, { ...req, method: 'PUT' });
 	return parseJSONResponse(raw, { expect: 'void' });
 };

--- a/src/functions/users/create-one-user.ts
+++ b/src/functions/users/create-one-user.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
@@ -30,7 +29,7 @@ export const makeCreateOneUser = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			const rawID = await parseJSONResponse<number>(raw);
 
 			const userID = rawID.toString();

--- a/src/functions/users/delete-one-user.ts
+++ b/src/functions/users/delete-one-user.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeDeleteOneUser = (context: APIContext) => {
 	return async (userID: string): Promise<void> => {
@@ -15,7 +15,7 @@ export const makeDeleteOneUser = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'DELETE' });
+		const raw = await context.fetch(url, { ...req, method: 'DELETE' });
 		return parseJSONResponse(raw, { expect: 'void' });
 	};
 };

--- a/src/functions/users/get-all-users.ts
+++ b/src/functions/users/get-all-users.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawUser, toUser, User } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetAllUsers = (context: APIContext) => {
 	const templatePath = '/api/users';
@@ -16,7 +16,7 @@ export const makeGetAllUsers = (context: APIContext) => {
 	return async (): Promise<Array<User>> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawUser> | null>(raw)) ?? [];
 		return rawRes.map(toUser);
 	};

--- a/src/functions/users/get-my-user.ts
+++ b/src/functions/users/get-my-user.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawUser, toUser, User } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetMyUser = (context: APIContext) => {
 	const templatePath = '/api/info/whoami';
@@ -16,7 +16,7 @@ export const makeGetMyUser = (context: APIContext) => {
 	return async (): Promise<User> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawUser>(raw);
 		return toUser(rawRes);
 	};

--- a/src/functions/users/get-one-user.ts
+++ b/src/functions/users/get-one-user.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { RawUser, toUser, User } from '~/models';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetOneUser = (context: APIContext) => {
 	return async (userID: string): Promise<User> => {
@@ -15,7 +15,7 @@ export const makeGetOneUser = (context: APIContext) => {
 		const url = buildURL(templatePath, { ...context, protocol: 'http', pathParams: { userID } });
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawUser>(raw);
 		return toUser(rawRes);
 	};

--- a/src/functions/users/get-users-by-group.ts
+++ b/src/functions/users/get-users-by-group.ts
@@ -8,7 +8,7 @@
 
 import { RawUser, toUser, User } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeGetUsersByGroup = (context: APIContext) => {
 	return async (groupID: NumericID): Promise<Array<User>> => {
@@ -17,7 +17,7 @@ export const makeGetUsersByGroup = (context: APIContext) => {
 
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const raw = await fetch(url, { ...req, method: 'GET' });
+		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = (await parseJSONResponse<Array<RawUser> | null>(raw)) ?? [];
 		return rawRes.map(toUser);
 	};

--- a/src/functions/users/update-one-user-information.ts
+++ b/src/functions/users/update-one-user-information.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	omitUndefinedShallow,
 	parseJSONResponse,
@@ -28,7 +27,7 @@ export const makeUpdateOneUserInformation = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/users/update-one-user-locked-state.ts
+++ b/src/functions/users/update-one-user-locked-state.ts
@@ -7,7 +7,7 @@
  **************************************************************************/
 
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeUpdateOneUserLockedState = (context: APIContext) => {
 	return async (userID: NumericID, lock: boolean): Promise<void> => {
@@ -18,7 +18,7 @@ export const makeUpdateOneUserLockedState = (context: APIContext) => {
 			const req = buildHTTPRequestWithAuthFromContext(context);
 
 			const method = lock ? 'PUT' : 'DELETE';
-			const raw = await fetch(url, { ...req, method });
+			const raw = await context.fetch(url, { ...req, method });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/users/update-one-user-password.ts
+++ b/src/functions/users/update-one-user-password.ts
@@ -11,7 +11,6 @@ import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
 	buildURL,
-	fetch,
 	HTTPRequestOptions,
 	omitUndefinedShallow,
 	parseJSONResponse,
@@ -32,7 +31,7 @@ export const makeUpdateOneUserPassword = (context: APIContext) => {
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
-			const raw = await fetch(url, { ...req, method: 'PUT' });
+			const raw = await context.fetch(url, { ...req, method: 'PUT' });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/users/update-one-user-role.ts
+++ b/src/functions/users/update-one-user-role.ts
@@ -8,7 +8,7 @@
 
 import { UserRole } from '~/models';
 import { NumericID } from '~/value-objects';
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeUpdateOneUserRole = (context: APIContext) => {
 	return async (userID: NumericID, role: UserRole): Promise<void> => {
@@ -19,7 +19,7 @@ export const makeUpdateOneUserRole = (context: APIContext) => {
 			const req = buildHTTPRequestWithAuthFromContext(context);
 
 			const method = role === 'admin' ? 'PUT' : 'DELETE';
-			const raw = await fetch(url, { ...req, method });
+			const raw = await context.fetch(url, { ...req, method });
 			return parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error) throw err;

--- a/src/functions/utils/api-context.ts
+++ b/src/functions/utils/api-context.ts
@@ -6,8 +6,11 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
+import { fetch } from './fetch';
+
 export interface APIContext {
 	host: string;
 	useEncryption: boolean;
 	authToken: string | null;
+	fetch: typeof fetch;
 }

--- a/src/functions/web-server/restart-web-server.ts
+++ b/src/functions/web-server/restart-web-server.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeRestartWebServer = (context: APIContext) => {
 	const templatePath = '/api/restart/webserver';
@@ -16,7 +16,7 @@ export const makeRestartWebServer = (context: APIContext) => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
 		try {
-			const raw = await fetch(url, { ...req, method: 'POST' });
+			const raw = await context.fetch(url, { ...req, method: 'POST' });
 			await parseJSONResponse(raw, { expect: 'void' });
 		} catch (err) {
 			if (err instanceof Error && err.message.includes('socket hang up')) return;

--- a/src/functions/web-server/web-server-is-distributed.ts
+++ b/src/functions/web-server/web-server-is-distributed.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, fetch, parseJSONResponse } from '../utils';
+import { APIContext, buildHTTPRequestWithAuthFromContext, buildURL, parseJSONResponse } from '../utils';
 
 export const makeWebServerIsDistributed = (context: APIContext) => {
 	const templatePath = '/api/distributed';
@@ -15,7 +15,7 @@ export const makeWebServerIsDistributed = (context: APIContext) => {
 	return async (): Promise<boolean> => {
 		const req = buildHTTPRequestWithAuthFromContext(context);
 
-		const rawRes = await fetch(url, { ...req, method: 'GET' });
+		const rawRes = await context.fetch(url, { ...req, method: 'GET' });
 		const rawData = await parseJSONResponse<RawDistributedWebServerResponse>(rawRes);
 		return rawData.Distributed;
 	};

--- a/src/tests/config.ts
+++ b/src/tests/config.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { APIContext } from '~/functions/utils';
+import { APIContext, fetch } from '~/functions/utils';
 import { getEnvVar } from './get-env-var';
 
 export * from './paths';
@@ -19,6 +19,7 @@ export const TEST_BASE_API_CONTEXT: APIContext = {
 	host: TEST_HOST,
 	useEncryption: false,
 	authToken: TEST_AUTH_TOKEN,
+	fetch: fetch,
 };
 
 const getBooleanEnv = (envVar: string): boolean | null => {


### PR DESCRIPTION
Address #252

- Add the fetch property in the APIContext
- Add fetch as option in the GravwellClient constructor
- If fetch was not injected in options, use the default function
- Use fetch from APIContext in all API calls