### PR TITLE
Modify Timeframe types, account for possible Metadata states of `SavedQuery`s

### DIFF
--- a/src/functions/dashboards/create-one-dashboard.spec.ts
+++ b/src/functions/dashboards/create-one-dashboard.spec.ts
@@ -56,7 +56,7 @@ describe('createOneDashboard()', () => {
 						searchIndex: 0,
 					},
 				],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			};
 
 			const dashboard = await createOneDashboard(data);

--- a/src/functions/dashboards/delete-one-dashboard.spec.ts
+++ b/src/functions/dashboards/delete-one-dashboard.spec.ts
@@ -32,13 +32,13 @@ describe('deleteOneDashboard()', () => {
 				name: 'D1',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D2',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 		];
 		const createPromises = creatableDashboards.map(creatable => createOneDashboard(creatable));

--- a/src/functions/dashboards/get-all-dashboards.spec.ts
+++ b/src/functions/dashboards/get-all-dashboards.spec.ts
@@ -34,13 +34,13 @@ describe('getAllDashboards()', () => {
 					name: 'D1',
 					searches: [],
 					tiles: [],
-					timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+					timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 				},
 				{
 					name: 'D2',
 					searches: [],
 					tiles: [],
-					timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+					timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 				},
 			];
 			const createPromises = creatableDashboards.map(creatable => createOneDashboard(creatable));

--- a/src/functions/dashboards/get-dashboards-authorized-to-me.spec.ts
+++ b/src/functions/dashboards/get-dashboards-authorized-to-me.spec.ts
@@ -43,13 +43,13 @@ describe('getDashboardsAuthorizedToMe()', () => {
 				name: 'D1',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D2',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 		];
 		const createPromises = creatableDashboards.map(creatable => createOneDashboard(creatable));
@@ -73,19 +73,19 @@ describe('getDashboardsAuthorizedToMe()', () => {
 				name: 'D3',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D4',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D5',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 		];
 

--- a/src/functions/dashboards/get-dashboards-by-group.spec.ts
+++ b/src/functions/dashboards/get-dashboards-by-group.spec.ts
@@ -77,14 +77,14 @@ xdescribe('getDashboardsByGroup()', () => {
 				groupIDs: [adminGroupID],
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D2',
 				groupIDs: [adminGroupID],
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 		];
 		const createPromises = creatableDashboards.map(creatable => createOneDashboard(creatable));
@@ -97,21 +97,21 @@ xdescribe('getDashboardsByGroup()', () => {
 				groupIDs: [analystGroupID],
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D4',
 				groupIDs: [analystGroupID],
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D5',
 				groupIDs: [analystGroupID],
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 		];
 

--- a/src/functions/dashboards/get-dashboards-by-user.spec.ts
+++ b/src/functions/dashboards/get-dashboards-by-user.spec.ts
@@ -40,13 +40,13 @@ describe('getDashboardsByUser()', () => {
 				name: 'D1',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D2',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 		];
 		const createPromises1 = creatableDashboards1.map(creatable => createOneDashboard(creatable));
@@ -70,19 +70,19 @@ describe('getDashboardsByUser()', () => {
 				name: 'D3',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D4',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 			{
 				name: 'D5',
 				searches: [],
 				tiles: [],
-				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+				timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 			},
 		];
 

--- a/src/functions/dashboards/get-one-dashboard.spec.ts
+++ b/src/functions/dashboards/get-one-dashboard.spec.ts
@@ -33,7 +33,7 @@ describe('getOneDashboard()', () => {
 			name: 'TEST',
 			searches: [],
 			tiles: [],
-			timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+			timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 		};
 		createdDashboard = await createOneDashboard(data);
 	});

--- a/src/functions/dashboards/update-one-dashboard.spec.ts
+++ b/src/functions/dashboards/update-one-dashboard.spec.ts
@@ -35,7 +35,7 @@ describe('updateOneDashboard()', () => {
 			name: 'Current name',
 			searches: [],
 			tiles: [],
-			timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H' },
+			timeframe: { durationString: 'PT1H', end: null, start: null, timeframe: 'PT1H', timezone: null },
 		};
 		createdDashboard = await createOneDashboard(data);
 	});
@@ -70,8 +70,8 @@ describe('updateOneDashboard()', () => {
 		{ gridOptions: { margin: 4 } },
 		{ gridOptions: {} },
 
-		{ timeframe: { durationString: '1M', timeframe: '1M' } },
-		{ timeframe: { durationString: 'A', timeframe: 'B', start: new Date(1000000), end: new Date() } },
+		{ timeframe: { durationString: '1M', timeframe: '1M', timezone: null } },
+		{ timeframe: { durationString: 'A', timeframe: 'B', start: new Date(1000000), end: new Date(), timezone: null } },
 
 		{ searches: [] },
 		{ searches: [{ name: 'Search 1', type: 'query', query: 'tag=netflow' }] },

--- a/src/functions/saved-queries/update-one-saved-query.spec.ts
+++ b/src/functions/saved-queries/update-one-saved-query.spec.ts
@@ -57,7 +57,7 @@ describe('updateOneSavedQuery()', () => {
 
 		{ query: 'tag=custom' },
 
-		{ defaultTimeframe: { timeframe: 'thisMonth', durationString: 'thisMonth' } },
+		{ defaultTimeframe: { timeframe: 'thisMonth', durationString: 'thisMonth', timezone: null } },
 		{ defaultTimeframe: null },
 	];
 	updateTests.forEach((_data, testIndex) => {

--- a/src/models/timeframe/is-timeframe.ts
+++ b/src/models/timeframe/is-timeframe.ts
@@ -14,7 +14,8 @@ export const isTimeframe = (value: any): value is Timeframe => {
 		const tf = <Timeframe>value;
 		return (
 			(isString(tf.durationString) || isNull(tf.durationString)) &&
-			isString(tf.timeframe) &&
+			(isString(tf.timeframe) || isNull(tf.timeframe)) &&
+			(isString(tf.timezone) || isNull(tf.timezone)) &&
 			(isDate(tf.start) || isNull(tf.start)) &&
 			(isDate(tf.end) || isNull(tf.end))
 		);

--- a/src/models/timeframe/raw-timeframe.ts
+++ b/src/models/timeframe/raw-timeframe.ts
@@ -7,8 +7,9 @@
  **************************************************************************/
 
 export interface RawTimeframe {
-	durationString: string | null;
-	timeframe: string;
+	durationString?: string | null;
+	timeframe?: string | null;
+	timezone?: string | null;
 	start?: string | null; // Timestamp
 	end?: string | null; // Timestamp
 }

--- a/src/models/timeframe/timeframe.ts
+++ b/src/models/timeframe/timeframe.ts
@@ -8,7 +8,8 @@
 
 export interface Timeframe {
 	durationString: string | null;
-	timeframe: string;
+	timeframe: string | null;
+	timezone: string | null;
 	start: Date | null;
 	end: Date | null;
 }

--- a/src/models/timeframe/to-raw-timeframe.ts
+++ b/src/models/timeframe/to-raw-timeframe.ts
@@ -12,6 +12,7 @@ import { RawTimeframe } from './raw-timeframe';
 export const toRawTimeframe = (tf: CreatableTimeframe): RawTimeframe => ({
 	durationString: tf.durationString,
 	timeframe: tf.timeframe,
+	timezone: tf.timezone,
 	start: tf.start?.toISOString() ?? null,
 	end: tf.end?.toISOString() ?? null,
 });

--- a/src/models/timeframe/to-timeframe.ts
+++ b/src/models/timeframe/to-timeframe.ts
@@ -10,8 +10,9 @@ import { RawTimeframe } from './raw-timeframe';
 import { Timeframe } from './timeframe';
 
 export const toTimeframe = (raw: RawTimeframe): Timeframe => ({
-	durationString: raw.durationString,
-	timeframe: raw.timeframe,
+	durationString: raw.durationString ?? null,
+	timeframe: raw.timeframe ?? null,
+	timezone: raw.timezone ?? null,
 	start: raw.start ? new Date(raw.start) : null,
 	end: raw.end ? new Date(raw.end) : null,
 });


### PR DESCRIPTION
The possible states of the `defaultTimeframe` attribute of a SavedQuery wasn't fully modeled in the RawTimeframe+Timeframe types and related functions (toTimeframe, isTimeframe).

RawTImeframe+Timeframe:
* timezone attribute added.
* durationString, timeframe, and timezone may be null/undefined.