### PR TITLE
gitea#4555 -- Add support for legacy dashboard tiles.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"prettier": "^2.2.1",
 				"rename-cli": "^6.2.1",
 				"rimraf": "^3.0.2",
-				"rxjs": "^7.4.0",
+				"rxjs": "^7.5.4",
 				"ts-node": "^9.1.1",
 				"tsc-alias": "^1.2.6",
 				"typescript": "^4.5.4",
@@ -64,7 +64,7 @@
 				"yargs": "^16.2.0"
 			},
 			"peerDependencies": {
-				"rxjs": "^7.4.0"
+				"rxjs": "^7.5.4"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -5004,12 +5004,12 @@
 			"dev": true
 		},
 		"node_modules/rxjs": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-			"integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+			"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "~2.1.0"
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/rxjs/node_modules/tslib": {
@@ -10269,12 +10269,12 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-			"integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+			"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
 			"dev": true,
 			"requires": {
-				"tslib": "~2.1.0"
+				"tslib": "^2.1.0"
 			},
 			"dependencies": {
 				"tslib": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"ws": "^7.4.3"
 	},
 	"peerDependencies": {
-		"rxjs": "~7.4.0"
+		"rxjs": "^7.5.4"
 	},
 	"devDependencies": {
 		"@types/base-64": "^0.1.3",
@@ -87,7 +87,7 @@
 		"prettier": "^2.2.1",
 		"rename-cli": "^6.2.1",
 		"rimraf": "^3.0.2",
-		"rxjs": "~7.4.0",
+		"rxjs": "^7.5.4",
 		"ts-node": "^9.1.1",
 		"tsc-alias": "^1.2.6",
 		"typescript": "^4.5.4",

--- a/src/models/dashboard/dashboard-tile.ts
+++ b/src/models/dashboard/dashboard-tile.ts
@@ -15,8 +15,9 @@ export interface DashboardTile {
 
 	/**
 	 * Index for the related search in Dashboard.searches.
+	 * `string` included for legacy dashboard support.
 	 */
-	searchIndex: number;
+	searchIndex: number | string;
 
 	renderer: string;
 

--- a/src/models/dashboard/is-dashboard-tile.ts
+++ b/src/models/dashboard/is-dashboard-tile.ts
@@ -17,7 +17,7 @@ export const isDashboardTile = (value: unknown): value is DashboardTile => {
 		return (
 			isNumericID(dt.id) &&
 			isString(dt.title) &&
-			isNumber(dt.searchIndex) &&
+			(isNumber(dt.searchIndex) || (isString(dt.searchIndex) && Number.isInteger(parseInt(dt.searchIndex, 10)))) &&
 			isString(dt.renderer) &&
 			/**	Due to the old dashboards we may not have `.rendererOptions` defined */
 			(isNull(dt.rendererOptions) || isDashboardRendererOptions(dt.rendererOptions)) &&

--- a/src/models/dashboard/raw-updatable-dashboard.ts
+++ b/src/models/dashboard/raw-updatable-dashboard.ts
@@ -45,7 +45,8 @@ export interface RawUpdatableDashboard {
 			renderer: string;
 			/**	Due to the old dashboards we may not have `x` and `y` defined */
 			span: { col: number; row: number; x?: number; y?: number };
-			searchesIndex: number;
+			/** `string` included for legacy dashboard support. */
+			searchesIndex: number | string;
 			/**	Due to the old dashboards we may not have `.rendererOptions` defined */
 			rendererOptions?: DashboardRendererOptions;
 		}>;


### PR DESCRIPTION
Two changes:
* Change rxjs version to match gui's version.
    * This allows `npm link`ing the js-client.
* Change tile's `searchIndex` from `number` to `number | string`.
    * Some legacy dashboards may use the string representation of an integer for this field.