### PR TITLE
Fix/handle ws error

### DIFF
--- a/src/functions/searches/attach-to-one-search/attach-to-one-search.ts
+++ b/src/functions/searches/attach-to-one-search/attach-to-one-search.ts
@@ -78,9 +78,12 @@ export const makeAttachToOneSearch = (context: APIContext) => {
 				closedSub.unsubscribe();
 			}
 
-			// Handles websocket hangups
+			// Handles websocket hangups from close or error
 			closedSub = from(rawSubscriptionP)
-				.pipe(concatMap(rawSubscription => rawSubscription.received$))
+				.pipe(
+					concatMap(rawSubscription => rawSubscription.received$),
+					catchError(() => EMPTY),
+				)
 				.subscribe({
 					complete: () => {
 						rawSubscriptionP = null;

--- a/src/functions/searches/subscribe-to-one-raw-search.ts
+++ b/src/functions/searches/subscribe-to-one-raw-search.ts
@@ -6,8 +6,8 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { Observable, timer } from 'rxjs';
-import { last, mapTo, startWith, takeUntil } from 'rxjs/operators';
+import { Observable, of, timer } from 'rxjs';
+import { catchError, last, mapTo, startWith, takeUntil } from 'rxjs/operators';
 import { RawSearchMessageReceived, RawSearchMessageSent } from '~/models';
 import { APIContext, APISubscription, apiSubscriptionFromWebSocket, buildURL, WebSocket } from '../utils';
 
@@ -20,7 +20,16 @@ export const makeSubscribeToOneRawSearch = (context: APIContext) => {
 		const rawSubscription = apiSubscriptionFromWebSocket<RawSearchMessageReceived, RawSearchMessageSent>(socket);
 
 		rawSubscription.send({ Subs: ['PONG', 'parse', 'search', 'attach'] });
-		const wsClosed$: Observable<void> = rawSubscription.sent$.pipe(startWith(undefined), mapTo(undefined), last());
+
+		const wsClosed$: Observable<void> = rawSubscription.sent$.pipe(
+			startWith(undefined),
+			// Even if the websocket hangs up due to an error, we want to emit, so that we can
+			// clean up the PONG subscription below
+			catchError(() => of(undefined)),
+			mapTo(undefined),
+			last(),
+		);
+
 		timer(1000, 5000)
 			.pipe(takeUntil(wsClosed$))
 			.subscribe(() => {

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.ts
@@ -81,9 +81,12 @@ export const makeSubscribeToOneSearch = (context: APIContext) => {
 				closedSub.unsubscribe();
 			}
 
-			// Handles websocket hangups
+			// Handles websocket hangups from close or error
 			closedSub = from(rawSubscriptionP)
-				.pipe(concatMap(rawSubscription => rawSubscription.received$))
+				.pipe(
+					concatMap(rawSubscription => rawSubscription.received$),
+					catchError(() => EMPTY),
+				)
 				.subscribe({
 					complete: () => {
 						rawSubscriptionP = null;


### PR DESCRIPTION
In some situations, some browsers emit an "error" event on websockets where other browsers would use "close".

I found that if the websocket emitted an error, we were unable to create a new websocket in the way we would if the websocket emitted a close. 

This PR:

- Adds logic to our websocket hangup logic, so that errors are treated the same as closes. That is, `rawSubscriptionP` is set to `null` in either case.,
- Handles errors when notifying the PONG subscription that it's time to close. On an error or close, we stop ponging gracefully.