### PR TITLE
#4915 -- Make Dashboard GUID optional.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
 				"prettier": "^2.2.1",
 				"rename-cli": "^6.2.1",
 				"rimraf": "^3.0.2",
-				"rxjs": "^7.5.4",
+				"rxjs": "^7.5.5",
 				"ts-node": "^9.1.1",
 				"tsc-alias": "^1.2.6",
 				"typescript": "^4.5.4",
@@ -5004,9 +5004,9 @@
 			"dev": true
 		},
 		"node_modules/rxjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-			"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+			"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
@@ -10269,9 +10269,9 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-			"integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+			"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
 			"dev": true,
 			"requires": {
 				"tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"prettier": "^2.2.1",
 		"rename-cli": "^6.2.1",
 		"rimraf": "^3.0.2",
-		"rxjs": "^7.5.4",
+		"rxjs": "^7.5.5",
 		"ts-node": "^9.1.1",
 		"tsc-alias": "^1.2.6",
 		"typescript": "^4.5.4",

--- a/src/models/dashboard/dashboard.ts
+++ b/src/models/dashboard/dashboard.ts
@@ -14,7 +14,7 @@ import { DashboardLiveUpdate, DashboardTile } from './index';
 
 export interface Dashboard {
 	id: NumericID;
-	globalID: UUID;
+	globalID?: UUID;
 
 	userID: NumericID;
 	groupIDs: Array<NumericID>;

--- a/src/models/dashboard/is-dashboard.ts
+++ b/src/models/dashboard/is-dashboard.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { isArray, isBoolean, isDate, isNull, isNumber, isString } from 'lodash';
+import { isArray, isBoolean, isDate, isNull, isNumber, isString, isUndefined } from 'lodash';
 import { Dashboard, isTimeframe, isVersion } from '~/models';
 import { isNumericID, isUUID } from '~/value-objects';
 import { isDashboardLiveUpdate } from './is-dashboard-live-update';
@@ -18,7 +18,7 @@ export const isDashboard = (value: unknown): value is Dashboard => {
 		const d = <Dashboard>value;
 		return (
 			isNumericID(d.id) &&
-			isUUID(d.globalID) &&
+			(isUndefined(d.globalID) || isUUID(d.globalID)) &&
 			isNumericID(d.userID) &&
 			isArray(d.groupIDs) &&
 			d.groupIDs.every(isNumericID) &&

--- a/src/models/dashboard/raw-dashboard.ts
+++ b/src/models/dashboard/raw-dashboard.ts
@@ -13,7 +13,7 @@ import { RawDashboardTile } from './raw-dashboard-tile';
 
 export interface RawDashboard {
 	ID: RawNumericID;
-	GUID: RawUUID;
+	GUID?: RawUUID;
 
 	UID: RawNumericID;
 	GIDs: Array<RawNumericID> | null;


### PR DESCRIPTION
Backend may supply no GUID. See [client/types/dashboard.go#L28](https://github.com/gravwell/gravwell/blob/v3.8.6/client/types/dashboard.go#L28).

rxjs version was bumped to match GUI version (which enable npm link to function).