### PR TITLE
Add tags fields for raw/text renderers

### DIFF
--- a/src/functions/utils/type-guards.ts
+++ b/src/functions/utils/type-guards.ts
@@ -1,0 +1,25 @@
+/*************************************************************************
+ * Copyright 2022 Gravwell, Inc. All rights reserved.
+ * Contact: <legal@gravwell.io>
+ *
+ * This software may be modified and distributed under the terms of the
+ * MIT license. See the LICENSE file for details.
+ **************************************************************************/
+
+import { Decoder, dict, guard, number } from 'decoders';
+
+/** Given a Decoder<T>, returns a type guard that returns true if value v is of type T */
+export const mkTypeGuard = <T>(d: Decoder<T>) => {
+	const g = guard(d);
+	return (v: unknown): v is T => {
+		try {
+			g(v);
+			return true;
+		} catch {
+			return false;
+		}
+	};
+};
+
+/** A type guard that returns true if the input parameter is a {[key: string]: number} */
+export const isDictOfNumber = mkTypeGuard(dict(number));

--- a/src/models/search/raw-search-message-received/request-entries-within-range/raw-renderer.ts
+++ b/src/models/search/raw-search-message-received/request-entries-within-range/raw-renderer.ts
@@ -7,6 +7,7 @@
  **************************************************************************/
 
 import { isArray, isUndefined } from 'lodash';
+import { isDictOfNumber } from '~/functions/utils/type-guards';
 import { isRawDataExplorerEntry } from '../../raw-data-explorer-entry';
 import { isRawSearchEntry, RawSearchEntry } from '../../raw-search-entry';
 import { RawSearchMessageReceivedRequestEntriesWithinRangeBaseData } from './base';
@@ -25,7 +26,7 @@ export const isRawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer = (
 		const t = v as RawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer;
 		const entriesOK = isUndefined(t.Entries) || (isArray(t.Entries) && t.Entries.every(isRawSearchEntry));
 		const exploreOK = isUndefined(t.Explore) || (isArray(t.Explore) && t.Explore.every(isRawDataExplorerEntry));
-		return entriesOK && exploreOK;
+		return entriesOK && exploreOK && isDictOfNumber(t.Tags);
 	} catch {
 		return false;
 	}

--- a/src/models/search/raw-search-message-received/request-entries-within-range/raw-renderer.ts
+++ b/src/models/search/raw-search-message-received/request-entries-within-range/raw-renderer.ts
@@ -13,6 +13,8 @@ import { RawSearchMessageReceivedRequestEntriesWithinRangeBaseData } from './bas
 
 export interface RawSearchMessageReceivedRequestEntriesWithinRangeRawRenderer
 	extends RawSearchMessageReceivedRequestEntriesWithinRangeBaseData {
+	/** Maps tag names to numeric IDs*/
+	Tags: { [tagname: string]: number };
 	Entries?: Array<RawSearchEntry>;
 }
 

--- a/src/models/search/raw-search-message-received/request-entries-within-range/text-renderer.ts
+++ b/src/models/search/raw-search-message-received/request-entries-within-range/text-renderer.ts
@@ -14,6 +14,8 @@ import { RawSearchMessageReceivedRequestEntriesWithinRangeBaseData } from './bas
 export interface RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer
 	extends RawSearchMessageReceivedRequestEntriesWithinRangeBaseData {
 	Entries?: Array<RawSearchEntry>;
+	/** Maps tag names to numeric IDs*/
+	Tags: { [tagname: string]: number };
 }
 
 export const isRawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer = (

--- a/src/models/search/raw-search-message-received/request-entries-within-range/text-renderer.ts
+++ b/src/models/search/raw-search-message-received/request-entries-within-range/text-renderer.ts
@@ -7,6 +7,7 @@
  **************************************************************************/
 
 import { isArray, isUndefined } from 'lodash';
+import { isDictOfNumber } from '~/functions/utils/type-guards';
 import { isRawDataExplorerEntry } from '../../raw-data-explorer-entry';
 import { isRawSearchEntry, RawSearchEntry } from '../../raw-search-entry';
 import { RawSearchMessageReceivedRequestEntriesWithinRangeBaseData } from './base';
@@ -25,7 +26,7 @@ export const isRawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer = (
 		const t = v as RawSearchMessageReceivedRequestEntriesWithinRangeTextRenderer;
 		const entriesOK = isUndefined(t.Entries) || (isArray(t.Entries) && t.Entries.every(isRawSearchEntry));
 		const exploreOK = isUndefined(t.Explore) || (isArray(t.Explore) && t.Explore.every(isRawDataExplorerEntry));
-		return entriesOK && exploreOK;
+		return entriesOK && exploreOK && isDictOfNumber(t.Tags);
 	} catch {
 		return false;
 	}

--- a/src/models/search/search-entries.ts
+++ b/src/models/search/search-entries.ts
@@ -268,6 +268,8 @@ export interface RawSearchEntries extends BaseSearchEntries {
 	// TODO
 	names: Array<string>;
 	data: Array<SearchEntry>;
+	/** Maps tag names to numeric IDs*/
+	tags: { [tagname: string]: number };
 }
 
 export const normalizeToRawSearchEntries = (
@@ -280,6 +282,7 @@ export const normalizeToRawSearchEntries = (
 		type: 'raw',
 		names: ['RAW'],
 		data: (v.Entries ?? []).map(toSearchEntry),
+		tags: v.Tags,
 	};
 };
 
@@ -311,6 +314,8 @@ export interface TextSearchEntries extends BaseSearchEntries {
 	// TODO
 	names: Array<string>;
 	data: Array<SearchEntry>;
+	/** Maps tag names to numeric IDs*/
+	tags: { [tagname: string]: number };
 }
 
 export const normalizeToTextSearchEntries = (
@@ -323,6 +328,7 @@ export const normalizeToTextSearchEntries = (
 		type: 'text',
 		names: ['DATA'],
 		data: (v.Entries ?? []).map(toSearchEntry),
+		tags: v.Tags,
 	};
 };
 


### PR DESCRIPTION
We were dropping the `Tags` field coming from `ID:18`'s for the `raw` and `text` renderers.

This PR keeps the tags field, because we need it to do proper tag ID lookups. 