### PR TITLE
fix(#336): Can't fetch a template just after creation.

### DIFF
--- a/.config/test-config/test-backend-alpha/Dockerfile
+++ b/.config/test-config/test-backend-alpha/Dockerfile
@@ -4,9 +4,9 @@ FROM gravwell/gravwell:latest AS gravwell-stable
 
 FROM base AS gravwell
 
-RUN apt-get update && apt-get --yes install curl gnupg2
-RUN curl https://update.gravwell.io/debian/update.gravwell.io.gpg.key | apt-key add -
-RUN echo 'deb [ arch=amd64 ] https://update.gravwell.io/debianalphaXYZZY/ community main' | tee /etc/apt/sources.list.d/gravwell.list
+RUN apt-get update && apt-get --yes install curl gnupg2 wget
+RUN wget -O /usr/share/keyrings/gravwell.asc https://gin.gravwell.io/debianalphaXYZZY/gin.gravwell.io.gpg.key
+RUN echo 'deb [ arch=amd64 signed-by=/usr/share/keyrings/gravwell.asc ] https://gin.gravwell.io/debianalphaXYZZY community main' > /etc/apt/sources.list.d/gravwell.list
 RUN apt-get update && apt-get --yes install \
   apt-transport-https gravwell
 

--- a/src/functions/search-groups/update-one-user-search-group.ts
+++ b/src/functions/search-groups/update-one-user-search-group.ts
@@ -22,8 +22,16 @@ export const makeUpdateOneUserSearchGroup = (context: APIContext) => {
 			const path = '/api/users/{userID}/searchgroup';
 			const url = buildURL(path, { ...context, protocol: 'http', pathParams: { userID } });
 
+			// To remove the search group ID, we need to send a DELETE request
+			if (isNull(groupID)) {
+				const req = buildHTTPRequestWithAuthFromContext(context);
+				const raw = await context.fetch(url, { ...req, method: 'DELETE' });
+				return parseJSONResponse(raw, { expect: 'void' });
+			}
+
+			// To change the search group ID, we need to send a PUT request
 			const body: UpdateOneUserSearchGroupRawRequest = {
-				GID: isNumber(groupID) ? groupID : isNull(groupID) ? groupID : parseInt(groupID, 10),
+				GID: isNumber(groupID) ? groupID : parseInt(groupID, 10),
 			};
 
 			const baseRequestOptions: HTTPRequestOptions = {

--- a/src/functions/searches/modify-one-query.spec.ts
+++ b/src/functions/searches/modify-one-query.spec.ts
@@ -88,7 +88,7 @@ describe('modifyOneQuery()', () => {
 			expect(newQuery).withContext(`Expect new query to be different than initial one`).not.toBe(query);
 			expect(newQuery)
 				.withContext(`Expect new query to contain the applied filter`)
-				.toBe(`tag=${tag} json value.foo == "50" as "foo" | table`);
+				.toBe(`tag=${tag} json "value.foo" == "50" as "foo" | table`);
 		}),
 	);
 
@@ -112,7 +112,7 @@ describe('modifyOneQuery()', () => {
 			};
 			await expectAsync(modifyOneQuery(query, [filter]))
 				.withContext(`Expect invalid filter to cause an error`)
-				.toBeRejectedWithError(Error, 'netflow (module idx 0) error: Malformed IPv4 Address');
+				.toBeRejectedWithError(Error, 'netflow (module idx 0) error: Malformed IPv6 Address');
 		}),
 	);
 });

--- a/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
@@ -239,7 +239,7 @@ describe('subscribeToOneExplorerSearch()', () => {
 		const elementFilters: Array<ElementFilter> = [
 			{ path: 'value.foo', operation: '!=', value: '50', tag, module: 'json', arguments: null },
 		];
-		const query = `tag=${tag} json value.foo != "50" as "foo" | raw`;
+		const query = `tag=${tag} json "value.foo" != "50" as "foo" | raw`;
 		const countAfterFilter = count - 1;
 
 		const filter: SearchFilter = {

--- a/src/functions/templates/create-one-template.ts
+++ b/src/functions/templates/create-one-template.ts
@@ -6,8 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { CreatableTemplate, Template, toRawCreatableTemplate } from '~/models';
-import { UUID } from '~/value-objects';
+import { CreatableTemplate, RawTemplate, Template, toRawCreatableTemplate, toTemplate } from '~/models';
 import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
@@ -15,11 +14,8 @@ import {
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
-import { makeGetOneTemplate } from './get-one-template';
 
 export const makeCreateOneTemplate = (context: APIContext) => {
-	const getOneTemplate = makeGetOneTemplate(context);
-
 	const templatePath = '/api/templates';
 	const url = buildURL(templatePath, { ...context, protocol: 'http' });
 
@@ -31,10 +27,9 @@ export const makeCreateOneTemplate = (context: APIContext) => {
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
 			const raw = await context.fetch(url, { ...req, method: 'POST' });
-			const rawID = await parseJSONResponse<UUID>(raw);
+			const rawRes = await parseJSONResponse<RawTemplate>(raw);
 
-			const templateID = rawID.toString();
-			return await getOneTemplate(templateID);
+			return toTemplate(rawRes);
 		} catch (err) {
 			if (err instanceof Error) throw err;
 			throw Error('Unknown error');

--- a/src/models/token/token-capability.ts
+++ b/src/models/token/token-capability.ts
@@ -59,4 +59,6 @@ export enum TokenCapability {
 	'SystemInfoRead' = 'SystemInfoRead',
 	'TokenRead' = 'TokenRead',
 	'TokenWrite' = 'TokenWrite',
+	'SecretRead' = 'SecretRead',
+	'SecretWrite' = 'SecretWrite',
 }


### PR DESCRIPTION
Adresses: [#336](https://github.com/gravwell/js-client/issues/336)

Important to say that, the issue was even bigger than what was described on `gitea`, so when any template was created, an 400 request was received and didn't go to `/templates` page after clicking on the save button. (And probably that's why drone was failing on template tests)

https://user-images.githubusercontent.com/69917459/173917689-1683d244-677f-4625-9dab-7c1405c393b2.mp4


With the current solution, beyond the fact, that the template is working, and the drone will probably be fixed, now we do one request (create one template) to the back-end instead of two (create one template and get one template).

After the implementation, here is the behavior on the template page (add, edit and delete works correctly):

https://user-images.githubusercontent.com/69917459/173919580-54545f06-5111-4331-9330-e92a4bdbc9d2.mp4




