### PR TITLE
#(no-issue): Update gravwell alpha backend URLs in `Dockerfile`

### DIFF
--- a/.config/test-config/test-backend-alpha/Dockerfile
+++ b/.config/test-config/test-backend-alpha/Dockerfile
@@ -4,9 +4,9 @@ FROM gravwell/gravwell:latest AS gravwell-stable
 
 FROM base AS gravwell
 
-RUN apt-get update && apt-get --yes install curl gnupg2
-RUN curl https://update.gravwell.io/debian/update.gravwell.io.gpg.key | apt-key add -
-RUN echo 'deb [ arch=amd64 ] https://update.gravwell.io/debianalphaXYZZY/ community main' | tee /etc/apt/sources.list.d/gravwell.list
+RUN apt-get update && apt-get --yes install curl gnupg2 wget
+RUN wget -O /usr/share/keyrings/gravwell.asc https://gin.gravwell.io/debianalphaXYZZY/gin.gravwell.io.gpg.key
+RUN echo 'deb [ arch=amd64 signed-by=/usr/share/keyrings/gravwell.asc ] https://gin.gravwell.io/debianalphaXYZZY community main' > /etc/apt/sources.list.d/gravwell.list
 RUN apt-get update && apt-get --yes install \
   apt-transport-https gravwell
 

--- a/src/functions/templates/create-one-template.ts
+++ b/src/functions/templates/create-one-template.ts
@@ -6,8 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { CreatableTemplate, Template, toRawCreatableTemplate } from '~/models';
-import { UUID } from '~/value-objects';
+import { CreatableTemplate, RawTemplate, Template, toRawCreatableTemplate, toTemplate } from '~/models';
 import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,
@@ -15,11 +14,8 @@ import {
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
-import { makeGetOneTemplate } from './get-one-template';
 
 export const makeCreateOneTemplate = (context: APIContext) => {
-	const getOneTemplate = makeGetOneTemplate(context);
-
 	const templatePath = '/api/templates';
 	const url = buildURL(templatePath, { ...context, protocol: 'http' });
 
@@ -31,10 +27,9 @@ export const makeCreateOneTemplate = (context: APIContext) => {
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
 			const raw = await context.fetch(url, { ...req, method: 'POST' });
-			const rawID = await parseJSONResponse<UUID>(raw);
+			const rawRes = await parseJSONResponse<RawTemplate>(raw);
 
-			const templateID = rawID.toString();
-			return await getOneTemplate(templateID);
+			return toTemplate(rawRes);
 		} catch (err) {
 			if (err instanceof Error) throw err;
 			throw Error('Unknown error');


### PR DESCRIPTION
Months ago, gravwell started to serve the backend alpha in a different domain, `gin.gravwell.io`. But JSClient is using the old one `update.gravwell.io`

This PR replaces the old URLs with the new ones.