### PR TITLE
fix(#343): Replace the `templatePath` to `/api/autoextractors/test`

### DIFF
--- a/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
+++ b/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
@@ -16,7 +16,7 @@ import {
 } from '../utils';
 
 export const makeIsValidAutoExtractorSyntax = (context: APIContext) => {
-	const templatePath = '/api/autoextractors';
+	const templatePath = '/api/autoextractors/test';
 	const url = buildURL(templatePath, { ...context, protocol: 'http' });
 
 	return async (data: CreatableAutoExtractor): Promise<IsValidAutoExtractorSyntaxResponse> => {


### PR DESCRIPTION
Addresses https://github.com/gravwell/js-client/issues/343

The makeIsValidAutoExtractorSyntax function was using the wrong API endpoint. This PR corrects this mistaken endpoint.