### PR TITLE
frontend issues 3287: Add support for extraction element filters.

### DIFF
--- a/src/functions/searches/subscribe-to-query-parsing.ts
+++ b/src/functions/searches/subscribe-to-query-parsing.ts
@@ -9,7 +9,15 @@
 import { Observable, timer } from 'rxjs';
 import { filter, last, map, mapTo, startWith, takeUntil } from 'rxjs/operators';
 import { ElementFilter, Query, RawQuery } from '~/models';
-import { RawElementFilter, RawPongMessageSent, toElementFilter, ValidatedQuery } from '~/models/search';
+import {
+	isOperationFilter,
+	RawElementFilter,
+	RawExtractionFilter,
+	RawOperationFilter,
+	RawPongMessageSent,
+	toElementFilter,
+	ValidatedQuery,
+} from '~/models/search';
 import { APIContext, APISubscription, apiSubscriptionFromWebSocket, buildURL, WebSocket } from '../utils';
 
 export const makeSubscribeToOneQueryParsing = (context: APIContext) => {
@@ -75,14 +83,26 @@ export const makeSubscribeToOneQueryParsing = (context: APIContext) => {
 					},
 				};
 				if (msg.filters.length !== 0)
-					rawMsg.data.Filters = msg.filters.map(f => ({
-						Tag: f.tag,
-						Module: f.module,
-						Path: f.path,
-						Args: f.arguments ?? undefined,
-						Op: f.operation,
-						Value: f.value,
-					}));
+					rawMsg.data.Filters = msg.filters.map(f => {
+						if (isOperationFilter(f)) {
+							const opFilter: RawOperationFilter = {
+								Tag: f.tag,
+								Module: f.module,
+								Path: f.path,
+								Args: f.arguments ?? undefined,
+								Op: f.operation,
+								Value: f.value,
+							};
+							return opFilter;
+						}
+						const exFilter: RawExtractionFilter = {
+							Tag: f.tag,
+							Module: f.module,
+							Path: f.path,
+							Args: f.arguments ?? undefined,
+						};
+						return exFilter;
+					});
 				await rawSubscription.send(rawMsg);
 			},
 			received$,

--- a/src/models/search/element-filter.ts
+++ b/src/models/search/element-filter.ts
@@ -6,14 +6,38 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { ElementFilterOperation } from './element-filter-operation';
+import { isString } from 'lodash';
+import { ElementFilterOperation, isElementFilterOperation } from './element-filter-operation';
 
-export interface ElementFilter {
+/**
+ * Filter to perform an operation on a field.
+ */
+export interface OperationFilter {
 	tag: string;
 	module: string;
-
 	path: string;
 	arguments: string | null;
 	operation: ElementFilterOperation;
 	value: string;
 }
+
+export const isOperationFilter = (v: ElementFilter): v is OperationFilter => {
+	try {
+		const ef = <OperationFilter>v;
+		return isElementFilterOperation(ef.operation) && isString(ef.value);
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Filter to extract a field.
+ */
+export interface ExtractionFilter {
+	tag: string;
+	module: string;
+	path: string;
+	arguments: string | null;
+}
+
+export type ElementFilter = OperationFilter | ExtractionFilter;

--- a/src/models/search/raw-element-filter.ts
+++ b/src/models/search/raw-element-filter.ts
@@ -6,7 +6,39 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { RawElementFilterOperation } from './element-filter-operation';
+import { isString } from 'lodash';
+import { isRawElementFilterOperation, RawElementFilterOperation } from './element-filter-operation';
+
+/**
+ * Filter to perform an operation on a field.
+ */
+export interface RawOperationFilter {
+	Tag: string;
+	Module: string;
+	Path: string;
+	Args?: string | undefined;
+	Op: RawElementFilterOperation;
+	Value: string;
+}
+
+export const isRawOperationFilter = (v: RawElementFilter): v is RawOperationFilter => {
+	try {
+		const ef = <RawOperationFilter>v;
+		return isRawElementFilterOperation(ef.Op) && isString(ef.Value);
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Filter to extract a field.
+ */
+export interface RawExtractionFilter {
+	Tag: string;
+	Module: string;
+	Path: string;
+	Args?: string | undefined;
+}
 
 /**
  * Describes a filter used by the Data Explorer. Filters may be included in parse requests
@@ -15,11 +47,4 @@ import { RawElementFilterOperation } from './element-filter-operation';
  * Most of the fields in this type are derived from IExploreElements from previous data explorer
  * search responses (REQ_EXPLORE_TS_RANGE)
  */
-export interface RawElementFilter {
-	Tag: string;
-	Module: string;
-	Path: string;
-	Args?: string | undefined;
-	Op: RawElementFilterOperation;
-	Value: string;
-}
+export type RawElementFilter = RawOperationFilter | RawExtractionFilter;

--- a/src/models/search/to-element-filter.ts
+++ b/src/models/search/to-element-filter.ts
@@ -6,14 +6,26 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { ElementFilter } from './element-filter';
-import { RawElementFilter } from './raw-element-filter';
+import { ElementFilter, ExtractionFilter, OperationFilter } from './element-filter';
+import { isRawOperationFilter, RawElementFilter } from './raw-element-filter';
 
-export const toElementFilter = (raw: RawElementFilter): ElementFilter => ({
-	tag: raw.Tag,
-	module: raw.Module,
-	path: raw.Path,
-	arguments: raw.Args ?? null,
-	operation: raw.Op,
-	value: raw.Value,
-});
+export const toElementFilter = (raw: RawElementFilter): ElementFilter => {
+	if (isRawOperationFilter(raw)) {
+		const opFilter: OperationFilter = {
+			tag: raw.Tag,
+			module: raw.Module,
+			path: raw.Path,
+			arguments: raw.Args ?? null,
+			operation: raw.Op,
+			value: raw.Value,
+		};
+		return opFilter;
+	}
+	const exFilter: ExtractionFilter = {
+		tag: raw.Tag,
+		module: raw.Module,
+		path: raw.Path,
+		arguments: raw.Args ?? null,
+	};
+	return exFilter;
+};


### PR DESCRIPTION
There are really two forms of element filters.
1. Operation filters (what's solely been implemented before this PR) that can be used to update a query to perform some operation
2. Extraction filters that can be used to update a query to extract a field (may help to "build up" a query using DE).

This PR has implemented the second. Original element filter types are now union types of one and two.