### PR TITLE
Fix(#372): Fix the ScheduledTask types

### DIFF
--- a/src/models/scheduled-task/is-scheduled-task-base.ts
+++ b/src/models/scheduled-task/is-scheduled-task-base.ts
@@ -10,7 +10,7 @@ import { isBoolean, isDate, isNull, isNumber, isString } from 'lodash';
 import { isNumericID, isUUID } from '~/value-objects';
 import { ScheduledTaskBase } from './scheduled-task-base';
 
-export const isScheduledTaskBase = (value: any): value is ScheduledTaskBase => {
+export const isScheduledTaskBase = (value: unknown): value is ScheduledTaskBase => {
 	try {
 		const ss = <ScheduledTaskBase>value;
 		return (
@@ -25,9 +25,8 @@ export const isScheduledTaskBase = (value: any): value is ScheduledTaskBase => {
 			isBoolean(ss.oneShot) &&
 			isBoolean(ss.isDisabled) &&
 			isDate(ss.lastUpdateDate) &&
-			isDate(ss.lastRunDate) &&
+			(isNull(ss.lastRun) || (isDate(ss.lastRun.date) && isNumber(ss.lastRun.duration))) &&
 			isNull(ss.lastSearchIDs) &&
-			isNumber(ss.lastRunDuration) &&
 			(isString(ss.lastError) || isNull(ss.lastError)) &&
 			isString(ss.schedule) &&
 			(isString(ss.timezone) || isNull(ss.timezone))

--- a/src/models/scheduled-task/raw-scheduled-task.ts
+++ b/src/models/scheduled-task/raw-scheduled-task.ts
@@ -49,7 +49,7 @@ export interface RawScheduledTask {
 	 * Search IDs of the most recently performed searches from this scheduled
 	 * search.
 	 */
-	LastSearchIDs: null;
+	LastSearchIDs: null | Array<Number>;
 
 	Timezone: string; //empty string is null
 

--- a/src/models/scheduled-task/scheduled-query-data.ts
+++ b/src/models/scheduled-task/scheduled-query-data.ts
@@ -11,5 +11,9 @@ import { ScheduledTaskBase } from './scheduled-task-base';
 export interface ScheduledQueryData extends ScheduledTaskBase {
 	type: 'query';
 	query: string;
-	searchSince: { lastRun: boolean; secondsAgo: number };
+	searchSince: {
+		lastRun: boolean;
+		/** Always negative and in seconds */
+		secondsAgo: number; // It's the same as `raw.Duration`
+	};
 }

--- a/src/models/scheduled-task/scheduled-task-base.ts
+++ b/src/models/scheduled-task/scheduled-task-base.ts
@@ -24,10 +24,12 @@ export interface ScheduledTaskBase {
 	isDisabled: boolean;
 
 	lastUpdateDate: Date;
-	lastRunDate: Date;
+	lastRun: null | {
+		date: Date;
+		duration: number;
+	};
 
-	lastSearchIDs: null;
-	lastRunDuration: number;
+	lastSearchIDs: null | Array<NumericID>;
 	lastError: string | null;
 
 	schedule: string;

--- a/src/models/scheduled-task/to-raw-creatable-scheduled-task.ts
+++ b/src/models/scheduled-task/to-raw-creatable-scheduled-task.ts
@@ -11,7 +11,7 @@ import { CreatableScheduledTask } from './creatable-scheduled-task';
 import { RawCreatableScheduledTask } from './raw-creatable-scheduled-task';
 
 export const toRawCreatableScheduledTask = (data: CreatableScheduledTask): RawCreatableScheduledTask => {
-	const base = {
+	const base: Omit<RawCreatableScheduledTask, 'DebugMode'> = {
 		Groups: (data.groupIDs ?? []).map(toRawNumericID),
 		Global: data.isGlobal ?? false,
 

--- a/src/models/scheduled-task/to-scheduled-task-base.ts
+++ b/src/models/scheduled-task/to-scheduled-task-base.ts
@@ -6,6 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
+import { isArray } from 'lodash';
 import { toNumericID } from '~/value-objects';
 import { RawScheduledTask } from './raw-scheduled-task';
 import { ScheduledTaskBase } from './scheduled-task-base';
@@ -26,12 +27,20 @@ export const toScheduledTaskBase = (raw: RawScheduledTask): ScheduledTaskBase =>
 	isDisabled: raw.Disabled,
 
 	lastUpdateDate: new Date(raw.Updated),
-	lastRunDate: new Date(raw.LastRun),
+	lastRun: isLastRunNull(raw.LastRun)
+		? null
+		: {
+				date: new Date(raw.LastRun),
+				duration: raw.LastRunDuration,
+		  },
 
-	lastSearchIDs: raw.LastSearchIDs,
-	lastRunDuration: raw.LastRunDuration,
+	lastSearchIDs: isArray(raw.LastSearchIDs) ? raw.LastSearchIDs.map(id => id.toString()) : null,
 	lastError: raw.LastError.trim() === '' ? null : raw.LastError,
 
 	schedule: raw.Schedule,
 	timezone: raw.Timezone.trim() === '' ? null : raw.Timezone,
 });
+
+/* "0001-01-01T00:00:00Z" is the value that the backend returns when the ScheduledSearch hasn't ever been run */
+const NULL_DATE = '0001-01-01T00:00:00Z';
+export const isLastRunNull = (lastRun: string): boolean => lastRun === NULL_DATE;


### PR DESCRIPTION
Addresses: #372, gravwell/frontend-issues#5339

### Changes
- Always that we don't have the last run the backend returns the `LastRun` property with the value = `'0001-01-01T00:00:00Z'`, so to make that easier to understand, always that the LastRun value be the same as the `'0001-01-01T00:00:00Z'` we will return `null` instead
- `RawScheduledTask` has the optional properties `LastRun` and `LastRunDuration`, but since we don't have a reason to have these properties separate, we create a new property in the `ScheduledTask` interface that has both:
```
lastRun: {
  date: raw.LastRun;
  duration: raw.LastRunDuration;
  }
```
