### PR TITLE
Fix(frontend issue 5359): SearchEntry's `data` field may be null.

### DIFF
--- a/.github/workflows/validate-alpha.yml
+++ b/.github/workflows/validate-alpha.yml
@@ -2,7 +2,7 @@ name: Validate Pull Request for Alpha
 
 on:
   pull_request:
-    branches: [dev]
+    branches: [dev, 'release/*']
 
 jobs:
   lint:

--- a/src/functions/searches/attach-to-one-explorer-search/attach-to-one-explorer-search.spec.ts
+++ b/src/functions/searches/attach-to-one-explorer-search/attach-to-one-explorer-search.spec.ts
@@ -183,6 +183,9 @@ describe('attachToOneExplorerSearch()', () => {
 				.toEqual(1);
 			const lastEntry = textEntries.data[0];
 			expect(lastEntry).toBeDefined();
+			if (!lastEntry.data) {
+				throw new Error('expected entry data to be string');
+			}
 			expect(base64.decode(lastEntry.data))
 				.withContext('The total count of entries should equal what we ingested')
 				.toEqual(`count ${count}`);
@@ -247,6 +250,9 @@ describe('attachToOneExplorerSearch()', () => {
 					return;
 				}
 
+				if (!entry.data) {
+					throw new Error('expected entry data to be string');
+				}
 				const value: Entry = JSON.parse(base64.decode(entry.data));
 				const enumeratedValues = entry.values;
 				const _timestamp = enumeratedValues.find(v => v.name === 'timestamp')!;
@@ -359,6 +365,9 @@ describe('attachToOneExplorerSearch()', () => {
 						return;
 					}
 
+					if (!entry.data) {
+						throw new Error('expected entry data to be string');
+					}
 					const value: Entry = JSON.parse(base64.decode(entry.data));
 					const enumeratedValues = entry.values;
 					const _timestamp = enumeratedValues.find(v => v.name === 'timestamp')!;
@@ -511,6 +520,9 @@ describe('attachToOneExplorerSearch()', () => {
 				////
 				expect(textEntries.data.length).withContext("Should be 90 entries since it's a 90 minute window").toEqual(90);
 				textEntries.data.forEach((entry, index) => {
+					if (!entry.data) {
+						throw new Error('expected entry data to be string');
+					}
 					const value: Entry = JSON.parse(base64.decode(entry.data));
 					expect(value.value).toEqual(minutes - index - 1);
 				});

--- a/src/functions/searches/attach-to-one-search/attach-to-one-search.spec.ts
+++ b/src/functions/searches/attach-to-one-search/attach-to-one-search.spec.ts
@@ -180,6 +180,9 @@ describe('attachToOneSearch()', () => {
 				.toEqual(1);
 			const lastEntry = textEntries.data[0];
 			expect(lastEntry).toBeDefined();
+			if (!lastEntry.data) {
+				throw new Error('expected entry data to be string');
+			}
 			expect(base64.decode(lastEntry.data))
 				.withContext('The total count of entries should equal what we ingested')
 				.toEqual(`count ${count}`);
@@ -244,6 +247,9 @@ describe('attachToOneSearch()', () => {
 					return;
 				}
 
+				if (!entry.data) {
+					throw new Error('expected entry data to be string');
+				}
 				const value: Entry = JSON.parse(base64.decode(entry.data));
 				const enumeratedValues = entry.values;
 				const _timestamp = enumeratedValues.find(v => v.name === 'timestamp')!;
@@ -356,6 +362,9 @@ describe('attachToOneSearch()', () => {
 						return;
 					}
 
+					if (!entry.data) {
+						throw new Error('expected entry data to be string');
+					}
 					const value: Entry = JSON.parse(base64.decode(entry.data));
 					const enumeratedValues = entry.values;
 					const _timestamp = enumeratedValues.find(v => v.name === 'timestamp')!;
@@ -496,6 +505,9 @@ describe('attachToOneSearch()', () => {
 				////
 				expect(textEntries.data.length).withContext("Should be 90 entries since it's a 90 minute window").toEqual(90);
 				textEntries.data.forEach((entry, index) => {
+					if (!entry.data) {
+						throw new Error('expected entry data to be string');
+					}
 					const value: Entry = JSON.parse(base64.decode(entry.data));
 					expect(value.value).toEqual(minutes - index - 1);
 				});

--- a/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-explorer-search/subscribe-to-one-explorer-search.spec.ts
@@ -182,6 +182,9 @@ describe('subscribeToOneExplorerSearch()', () => {
 					return;
 				}
 
+				if (!entry.data) {
+					throw new Error('expected entry data to be string');
+				}
 				const value: Entry = JSON.parse(base64.decode(entry.data));
 				const enumeratedValues = entry.values;
 				const _timestamp = enumeratedValues.find(v => v.name === 'timestamp');
@@ -490,7 +493,13 @@ describe('subscribeToOneExplorerSearch()', () => {
 						if (prevEntry === undefined || curEntry === undefined) {
 							throw new Error('Zipped values were not the same length.');
 						}
+						if (!prevEntry.data) {
+							throw new Error('expected entry data to be string');
+						}
 						const prevValue: Entry = JSON.parse(base64.decode(prevEntry.data));
+						if (!curEntry.data) {
+							throw new Error('expected entry data to be string');
+						}
 						const curValue: Entry = JSON.parse(base64.decode(curEntry.data));
 
 						return prevValue.value.foo > curValue.value.foo && isDesc;
@@ -507,6 +516,9 @@ describe('subscribeToOneExplorerSearch()', () => {
 					return;
 				}
 
+				if (!entry.data) {
+					throw new Error('expected entry data to be string');
+				}
 				const value: Entry = JSON.parse(base64.decode(entry.data));
 				const enumeratedValues = entry.values;
 				const [_timestamp, _value] = enumeratedValues;

--- a/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
+++ b/src/functions/searches/subscribe-to-one-search/subscribe-to-one-search.spec.ts
@@ -172,6 +172,9 @@ describe('subscribeToOneSearch()', () => {
 				.toEqual(1);
 			const lastEntry = textEntries.data[0];
 			expect(lastEntry).toBeDefined();
+			if (!lastEntry.data) {
+				throw new Error('expected entry data to be string');
+			}
 			expect(base64.decode(lastEntry.data))
 				.withContext('The total count of entries should equal what we ingested')
 				.toEqual(`count ${count}`);
@@ -232,6 +235,9 @@ describe('subscribeToOneSearch()', () => {
 					return;
 				}
 
+				if (!entry.data) {
+					throw new Error('expected entry data to be string');
+				}
 				const value: Entry = JSON.parse(base64.decode(entry.data));
 				const enumeratedValues = entry.values;
 				const _timestamp = enumeratedValues.find(v => v.name === 'timestamp')!;
@@ -339,6 +345,9 @@ describe('subscribeToOneSearch()', () => {
 						return;
 					}
 
+					if (!entry.data) {
+						throw new Error('expected entry data to be string');
+					}
 					const value: Entry = JSON.parse(base64.decode(entry.data));
 					const enumeratedValues = entry.values;
 					const _timestamp = enumeratedValues.find(v => v.name === 'timestamp')!;
@@ -582,6 +591,9 @@ describe('subscribeToOneSearch()', () => {
 					return;
 				}
 
+				if (!entry.data) {
+					throw new Error('expected entry data to be string');
+				}
 				const value: Entry = JSON.parse(base64.decode(entry.data));
 				const enumeratedValues = entry.values;
 				const [_timestamp, _value] = enumeratedValues;
@@ -676,6 +688,9 @@ describe('subscribeToOneSearch()', () => {
 				////
 				expect(textEntries.data.length).withContext("Should be 90 entries since it's a 90 minute window").toEqual(90);
 				textEntries.data.forEach((entry, index) => {
+					if (!entry.data) {
+						throw new Error('expected entry data to be string');
+					}
 					const value: Entry = JSON.parse(base64.decode(entry.data));
 					expect(value.value).toEqual(minutes - index - 1);
 				});

--- a/src/models/search/raw-search-entry.ts
+++ b/src/models/search/raw-search-entry.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { isArray, isNumber, isString } from 'lodash';
+import { isArray, isNull, isNumber, isString } from 'lodash';
 
 // Named SearchEntry in Go
 /**
@@ -16,7 +16,7 @@ export interface RawSearchEntry {
 	TS: string;
 	Tag: number;
 	SRC: string; // IP
-	Data: string; // base64
+	Data: string | null; // base64
 	Enumerated: Array<RawEnumeratedPair>;
 }
 
@@ -27,7 +27,7 @@ export const isRawSearchEntry = (v: unknown): v is RawSearchEntry => {
 			isString(s.TS) &&
 			isString(s.SRC) &&
 			isNumber(s.Tag) &&
-			isString(s.Data) &&
+			(isString(s.Data) || isNull(s.Data)) &&
 			isArray(s.Enumerated) &&
 			s.Enumerated.every(isRawEnumeratedPair)
 		);
@@ -44,7 +44,7 @@ export interface RawStringTagEntry {
 	TS: string;
 	Tag: string;
 	SRC: string; // IP
-	Data: string; // base64
+	Data: string | null; // base64
 	Enumerated: Array<RawEnumeratedPair>;
 }
 
@@ -55,7 +55,7 @@ export const isRawStringTagEntry = (v: unknown): v is RawStringTagEntry => {
 			isString(s.TS) &&
 			isString(s.Tag) &&
 			isString(s.SRC) &&
-			isString(s.Data) &&
+			(isString(s.Data) || isNull(s.Data)) &&
 			isArray(s.Enumerated) &&
 			s.Enumerated.every(isRawEnumeratedPair)
 		);

--- a/src/models/search/search-entry.ts
+++ b/src/models/search/search-entry.ts
@@ -12,7 +12,7 @@ export interface SearchEntry {
 	timestamp: Date;
 	tag: number;
 	/** Raw, binary or text data for the whole entry. Original data. */
-	data: string;
+	data: string | null;
 	values: Array<SearchEntryValue>;
 }
 


### PR DESCRIPTION
ipfix data within Data Explorer may have null `data` fields. SearchEntry and related types/functions have been updated to account for this.