### PR TITLE
ci: Bump Node/NPM versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js 12.16.3
+      - name: Use Node.js 16.14.0
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.3'
+          node-version: '16.14.0'
           registry-url: https://registry.npmjs.org/
-      - name: Use NPM 6.14.8
-        run: npm i -g npm@6.14.8
+      - name: Use NPM 8.5.3
+        run: npm i -g npm@8.5.3
 
       - name: Set the package version
         run: npm version --no-git-tag-version ${{github.event.release.tag_name}}


### PR DESCRIPTION
This PR addresses no issue.

The versions of node / NPM used by `npm-publish` were way behind the versions used in other workflows. This PR updates the versions to match.