### PR TITLE
fix: Set Content-Type as necessary

### DIFF
--- a/src/functions/actionables/create-one-actionable.ts
+++ b/src/functions/actionables/create-one-actionable.ts
@@ -27,6 +27,7 @@ export const makeCreateOneActionable = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableActionable(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/actionables/update-one-actionable.ts
+++ b/src/functions/actionables/update-one-actionable.ts
@@ -32,6 +32,7 @@ export const makeUpdateOneActionable = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableActionable(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/auth/login-one-user.ts
+++ b/src/functions/auth/login-one-user.ts
@@ -16,6 +16,7 @@ export const makeLoginOneUser = (context: APIContext) => {
 	return async (username: string, password: string): Promise<JWT> => {
 		const baseRequestOptions: HTTPRequestOptions = {
 			body: JSON.stringify({ User: username, Pass: password }),
+			headers: { 'Content-Type': 'application/json' },
 		};
 		const req = buildHTTPRequest(baseRequestOptions);
 

--- a/src/functions/auto-extractors/create-one-auto-extractor.ts
+++ b/src/functions/auto-extractors/create-one-auto-extractor.ts
@@ -28,6 +28,7 @@ export const makeCreateOneAutoExtractor = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableAutoExtractor(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/auto-extractors/generate-auto-extractors.ts
+++ b/src/functions/auto-extractors/generate-auto-extractors.ts
@@ -26,6 +26,7 @@ export const makeGenerateAutoExtractors = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawGeneratableAutoExtractor(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
+++ b/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
@@ -23,6 +23,7 @@ export const makeIsValidAutoExtractorSyntax = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableAutoExtractor(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/auto-extractors/update-one-auto-extractor.ts
+++ b/src/functions/auto-extractors/update-one-auto-extractor.ts
@@ -36,6 +36,7 @@ export const makeUpdateOneAutoExtractor = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableAutoExtractor(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/dashboards/create-one-dashboard.ts
+++ b/src/functions/dashboards/create-one-dashboard.ts
@@ -27,6 +27,7 @@ export const makeCreateOneDashboard = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableDashboard(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/dashboards/update-one-dashboard.ts
+++ b/src/functions/dashboards/update-one-dashboard.ts
@@ -28,6 +28,7 @@ export const makeUpdateOneDashboard = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableDashboard(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/files/update-one-file.ts
+++ b/src/functions/files/update-one-file.ts
@@ -44,6 +44,7 @@ export const makeUpdateOneFile = (context: APIContext) => {
 
 				const baseRequestOptions: HTTPRequestOptions = {
 					body: JSON.stringify(toRawUpdatableFile(data, current)),
+					headers: { 'Content-Type': 'application/json' },
 				};
 				const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/groups/add-one-user-to-many-groups.ts
+++ b/src/functions/groups/add-one-user-to-many-groups.ts
@@ -24,6 +24,7 @@ export const makeAddOneUserToManyGroups =
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify({ GIDs: groupIDs.map(toRawNumericID) }),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/groups/create-one-group.ts
+++ b/src/functions/groups/create-one-group.ts
@@ -26,6 +26,7 @@ export const makeCreateOneGroup = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableGroup(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/groups/update-one-group.ts
+++ b/src/functions/groups/update-one-group.ts
@@ -27,6 +27,7 @@ export const makeUpdateOneGroup =
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableGroup(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/ingestors/ingest-json-entries.ts
+++ b/src/functions/ingestors/ingest-json-entries.ts
@@ -23,6 +23,7 @@ export const makeIngestJSONEntries = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(entries.map(toRawCreatableJSONEntry)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/kits/build-one-local-kit.ts
+++ b/src/functions/kits/build-one-local-kit.ts
@@ -24,6 +24,7 @@ export const makeBuildOneLocalKit = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawBuildableKit(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/kits/install-one-kit.ts
+++ b/src/functions/kits/install-one-kit.ts
@@ -101,6 +101,7 @@ const makeQueueOneKitForInstallation =
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawInstallableKit(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/kits/upload-one-remote-kit.ts
+++ b/src/functions/kits/upload-one-remote-kit.ts
@@ -25,6 +25,7 @@ export const makeUploadOneRemoteKit =
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify({ remote: kitID }),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/logs/create-one-log.ts
+++ b/src/functions/logs/create-one-log.ts
@@ -25,6 +25,7 @@ export const makeCreateOneLog = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify({ Body: message }),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/logs/set-log-level.ts
+++ b/src/functions/logs/set-log-level.ts
@@ -22,6 +22,7 @@ export const makeSetLogLevel = (context: APIContext) => {
 	return async (level: LogLevel | 'off'): Promise<void> => {
 		const baseRequestOptions: HTTPRequestOptions = {
 			body: JSON.stringify({ Level: level === 'off' ? 'Off' : toRawLogLevel(level) }),
+			headers: { 'Content-Type': 'application/json' },
 		};
 		const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/macros/create-one-macro.ts
+++ b/src/functions/macros/create-one-macro.ts
@@ -27,6 +27,7 @@ export const makeCreateOneMacro = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableMacro(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/macros/update-one-macro.ts
+++ b/src/functions/macros/update-one-macro.ts
@@ -28,6 +28,7 @@ export const makeUpdateOneMacro = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableMacro(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/mail-server/create-server-test.ts
+++ b/src/functions/mail-server/create-server-test.ts
@@ -20,6 +20,7 @@ export const makeCreateServerTest =
 			const url = buildURL(MAIL_PATH, { ...context, protocol: 'http' });
 			const req = buildHTTPRequestWithAuthFromContext(context, {
 				body: JSON.stringify(toRawMailServerTestData(data)),
+				headers: { 'Content-Type': 'application/json' },
 			});
 			const rawRes = await context.fetch(url, { ...req, method: 'POST' });
 

--- a/src/functions/mail-server/update-config.ts
+++ b/src/functions/mail-server/update-config.ts
@@ -18,6 +18,7 @@ export const makeUpdateConfig =
 			const url = buildURL(MAIL_CONFIG_PATH, { ...context, protocol: 'http' });
 			const req = buildHTTPRequestWithAuthFromContext(context, {
 				body: JSON.stringify(toRawMailServerConfig(config)),
+				headers: { 'Content-Type': 'application/json' },
 			});
 			const rawRes = await context.fetch(url, { ...req, method: 'POST' });
 			// The API response is empty so we just check on status

--- a/src/functions/notifications/create-one-broadcasted-notification.ts
+++ b/src/functions/notifications/create-one-broadcasted-notification.ts
@@ -23,6 +23,7 @@ export const makeCreateOneBroadcastedNotification = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableBroadcastedNotification(creatable)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/notifications/create-one-targeted-notification.ts
+++ b/src/functions/notifications/create-one-targeted-notification.ts
@@ -39,6 +39,7 @@ export const makeCreateOneTargetedNotification =
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableTargetedNotification(_creatable)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/notifications/update-one-notification.ts
+++ b/src/functions/notifications/update-one-notification.ts
@@ -35,6 +35,7 @@ export const makeUpdateOneNotification = (context: APIContext) => {
 			}
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableNotification(updatable, currentNotification)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/playbooks/create-one-playbook.ts
+++ b/src/functions/playbooks/create-one-playbook.ts
@@ -27,6 +27,7 @@ export const makeCreateOnePlaybook = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatablePlaybook(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/playbooks/update-one-playbook.ts
+++ b/src/functions/playbooks/update-one-playbook.ts
@@ -33,6 +33,7 @@ export const makeUpdateOnePlaybook = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatablePlaybook(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/resources/create-one-resource.ts
+++ b/src/functions/resources/create-one-resource.ts
@@ -23,6 +23,7 @@ export const makeCreateOneResource = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableResource(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/resources/update-one-resource.ts
+++ b/src/functions/resources/update-one-resource.ts
@@ -39,6 +39,7 @@ export const makeUpdateOneResource = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableResourceMetadata(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/saved-queries/create-one-saved-query.ts
+++ b/src/functions/saved-queries/create-one-saved-query.ts
@@ -23,6 +23,7 @@ export const makeCreateOneSavedQuery = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableSavedQuery(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/saved-queries/update-one-saved-query.ts
+++ b/src/functions/saved-queries/update-one-saved-query.ts
@@ -28,6 +28,7 @@ export const makeUpdateOneSavedQuery = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableSavedQuery(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/scheduled-tasks/create-one-scheduled-task.ts
+++ b/src/functions/scheduled-tasks/create-one-scheduled-task.ts
@@ -37,6 +37,7 @@ export const makeCreateOneScheduledTask = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableScheduledTask(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/scheduled-tasks/update-one-scheduled-task.ts
+++ b/src/functions/scheduled-tasks/update-one-scheduled-task.ts
@@ -40,6 +40,7 @@ export const makeUpdateOneScheduledTask = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableScheduledTask(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/scripts/validate-one-script.ts
+++ b/src/functions/scripts/validate-one-script.ts
@@ -22,6 +22,7 @@ export const makeValidateOneScript = (context: APIContext) => {
 	return async (script: Script): Promise<ValidatedScript> => {
 		const baseRequestOptions: HTTPRequestOptions = {
 			body: JSON.stringify({ Script: script }),
+			headers: { 'Content-Type': 'application/json' },
 		};
 		const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/search-groups/update-one-user-search-group.ts
+++ b/src/functions/search-groups/update-one-user-search-group.ts
@@ -37,6 +37,7 @@ export const makeUpdateOneUserSearchGroup =
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(body),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/templates/create-one-template.ts
+++ b/src/functions/templates/create-one-template.ts
@@ -23,6 +23,7 @@ export const makeCreateOneTemplate = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableTemplate(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/templates/update-one-template.ts
+++ b/src/functions/templates/update-one-template.ts
@@ -32,6 +32,7 @@ export const makeUpdateOneTemplate = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableTemplate(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/tokens/create-one-token.ts
+++ b/src/functions/tokens/create-one-token.ts
@@ -23,6 +23,7 @@ export const makeCreateOneToken = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableToken(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/tokens/update-one-token.ts
+++ b/src/functions/tokens/update-one-token.ts
@@ -28,6 +28,7 @@ export const makeUpdateOneToken = (context: APIContext) => {
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableToken(data, current)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/user-preferences/update-one-user-preferences.ts
+++ b/src/functions/user-preferences/update-one-user-preferences.ts
@@ -22,6 +22,7 @@ export const makeUpdateOneUserPreferences =
 		const url = buildURL(templatePath, { ...context, protocol: 'http', pathParams: { userID } });
 		const baseRequestOptions: HTTPRequestOptions = {
 			body: JSON.stringify(preferences ?? {}),
+			headers: { 'Content-Type': 'application/json' },
 		};
 		const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/users/create-one-user.ts
+++ b/src/functions/users/create-one-user.ts
@@ -26,6 +26,7 @@ export const makeCreateOneUser = (context: APIContext) => {
 		try {
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawCreatableUser(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/users/update-one-user-information.ts
+++ b/src/functions/users/update-one-user-information.ts
@@ -25,6 +25,7 @@ export const makeUpdateOneUserInformation =
 
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(toRawUpdatableUserInformation(data)),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 

--- a/src/functions/users/update-one-user-password.ts
+++ b/src/functions/users/update-one-user-password.ts
@@ -29,6 +29,7 @@ export const makeUpdateOneUserPassword =
 			});
 			const baseRequestOptions: HTTPRequestOptions = {
 				body: JSON.stringify(body),
+				headers: { 'Content-Type': 'application/json' },
 			};
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes adding `Content-Type` headers to requests to better describe corresponding payloads.