### PR TITLE
chore: Update branch name

### DIFF
--- a/.github/workflows/validate-prod.yml
+++ b/.github/workflows/validate-prod.yml
@@ -2,7 +2,7 @@ name: Validate Pull Request for Production
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   lint:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ With an existing issue associated with your work, create a branch for your work 
 Other branch conventions are:
 
 - `dev` for the latest development version
-- `master` for the latest general released version
+- `main` for the latest general released version
 
 Once your work is done and [conforms with our style conventions](#style-conventions):
 


### PR DESCRIPTION
This PR addresses no issue.

It proposes updating source to account for the `master` -> `main` branch rename.