### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,8 @@ name: Deploy Docs to GitHub Pages
 on:
   push:
     # Every push on dev will run this action
-    branches: [dev]
+    branches:
+      - dev
 
 jobs:
   build:
@@ -11,10 +12,10 @@ jobs:
     concurrency: ci-${{github.ref}}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,22 +1,23 @@
-# This workflow will run tests using node and then publish a package to NPM when a release is created
+# This workflow will run tests using node and then publish a package to NPM when a release is released
 
 name: Publish Package to NPM
 
 on:
   release:
-    types: [created]
+    types:
+      - released
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
-          registry-url: https://registry.npmjs.org/
+
       - name: Use NPM 8.5.3
         run: npm i -g npm@8.5.3
 

--- a/.github/workflows/validate-alpha.yml
+++ b/.github/workflows/validate-alpha.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build image for Backend Alpha
         run: docker build -t gravwell-alpha .config/test-config/test-backend-alpha/
       - shell: bash
@@ -101,7 +101,7 @@ jobs:
           sleep 10
           curl --silent --fail http://localhost:8080/api/test || ( echo "api test failed"; exit 1 )
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build image for Backend Alpha
         run: docker build -t gravwell-alpha .config/test-config/test-backend-alpha/
       - shell: bash
@@ -170,7 +170,7 @@ jobs:
           sleep 10
           curl --silent --fail http://localhost:8080/api/test || ( echo "api test failed"; exit 1 )
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build image for Backend Alpha
         run: docker build -t gravwell-alpha .config/test-config/test-backend-alpha/
       - shell: bash
@@ -238,7 +238,7 @@ jobs:
           sleep 10
           curl --silent --fail http://localhost:8080/api/test || ( echo "api test failed"; exit 1 )
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3

--- a/.github/workflows/validate-prod.yml
+++ b/.github/workflows/validate-prod.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build image for Backend Beta
         run: docker build -t gravwell-beta .config/test-config/test-backend-beta/
       - shell: bash
@@ -101,7 +101,7 @@ jobs:
           sleep 10
           curl --silent --fail http://localhost:8080/api/test || ( echo "api test failed"; exit 1 )
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build image for Backend Beta
         run: docker build -t gravwell-beta .config/test-config/test-backend-beta/
       - shell: bash
@@ -170,7 +170,7 @@ jobs:
           sleep 10
           curl --silent --fail http://localhost:8080/api/test || ( echo "api test failed"; exit 1 )
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build image for Backend Beta
         run: docker build -t gravwell-beta .config/test-config/test-backend-beta/
       - shell: bash
@@ -238,7 +238,7 @@ jobs:
           sleep 10
           curl --silent --fail http://localhost:8080/api/test || ( echo "api test failed"; exit 1 )
       - name: Use Node.js 16.14.0
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '16.14.0'
       - run: npm i -g npm@8.5.3


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes...

- updating actions/checkout and actions/setup-node to use more recent releases
- changing the trigger for `npm-publish` to `release` instead of `create`. We don't want `npm publish` to run on drafts.