### PR TITLE
ci: Update Dockerfile to use new alpha package host

### DIFF
--- a/.config/test-config/test-backend-alpha/Dockerfile
+++ b/.config/test-config/test-backend-alpha/Dockerfile
@@ -5,8 +5,8 @@ FROM gravwell/gravwell:latest AS gravwell-stable
 FROM base AS gravwell
 
 RUN apt-get update && apt-get --yes install curl gnupg2 wget
-RUN wget -O /usr/share/keyrings/gravwell.asc https://gin.gravwell.io/debianalphaXYZZY/gin.gravwell.io.gpg.key
-RUN echo 'deb [ arch=amd64 signed-by=/usr/share/keyrings/gravwell.asc ] https://gin.gravwell.io/debianalphaXYZZY community main' > /etc/apt/sources.list.d/gravwell.list
+RUN wget -O /usr/share/keyrings/gravwell.asc https://update.gravwell.io/debian/update.gravwell.io.gpg.key
+RUN echo 'deb [ arch=amd64 signed-by=/usr/share/keyrings/gravwell.asc ] https://update.gravwell.io/debianalphaXYZZY community main' > /etc/apt/sources.list.d/gravwell.list
 RUN apt-get update && apt-get --yes install \
   apt-transport-https gravwell
 


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes changing a couple URLs to fix an issue where CI can't `apt install` the Gravwell backend.